### PR TITLE
Should support Python 3.8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 0.1
 ---
 
+### 0.1.12
+
+- Unreleased.
+
 ### 0.1.11
 
-- Unreleased
+- Supports Python 3.8, because Azure is still on 3.8.
 
 ### 0.1.10
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-simple-deploy
-version = 0.1.10
+version = 0.1.11
 description = A management command that auto-configures for deployment.
 long_description = file: README.md
 long_description_content_type=text/markdown
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Topic :: Internet :: WWW/HTTP
@@ -28,6 +29,6 @@ classifiers =
 [options]
 include_package_data = true
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.8
 install_requires =
     Django >=  3.0

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -64,7 +64,9 @@ class Command(BaseCommand):
          # Get project name. There are a number of ways to get the project
         #   name; for now we'll assume the root url config file has not
         #   been moved from the default location.
-        self.project_name = settings.ROOT_URLCONF.removesuffix('.urls')
+        # DEV: Use this code when we can require Python >=3.9.
+        # self.project_name = settings.ROOT_URLCONF.removesuffix('.urls')
+        self.project_name = settings.ROOT_URLCONF.replace('.urls', '')
 
         self.project_root = settings.BASE_DIR
         self.settings_path = f"{self.project_root}/{self.project_name}/settings.py"

--- a/simple_deploy/management/commands/utils/deploy_heroku.py
+++ b/simple_deploy/management/commands/utils/deploy_heroku.py
@@ -76,7 +76,9 @@ class HerokuDeployer:
         # Turn stdout info into a list of strings that we can then parse.
         #   If no app exists, stdout is empty and the output went to stderr.
         apps_info = apps_info.stdout.decode().split('\n')
-        self.heroku_app_name = apps_info[0].removeprefix('=== ')
+        # DEV: Use this code when we can require Python >=3.9.
+        # self.heroku_app_name = apps_info[0].removeprefix('=== ')
+        self.heroku_app_name = apps_info[0].replace('=== ', '')
 
         if self.heroku_app_name:
             self.stdout.write(f"    Found Heroku app: {self.heroku_app_name}")


### PR DESCRIPTION
Two simple changes removing `removeprefix()` and `removesuffix()` until the project can require Python >=3.9. Azure only supports 3.8 at this point as far as I can tell, and many people are still using 3.8.