### PR TITLE
Stream platformsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 0.5 - Supporting Fly.io, Platform.sh, and Heroku
 ---
 
+### 0.5.5
+
+- Streams output of `platform push`.
+
 ### 0.5.4
 
 - Streams output of long-running commands `fly postgres create` and `fly deploy`. This makes it much easier to know that the deployment is continuing, rather than hanging.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-simple-deploy
-version = 0.5.4
+version = 0.5.5
 description = A management command that auto-configures a Django project for deployment.
 long_description = file: README.md
 long_description_content_type=text/markdown

--- a/simple_deploy/management/commands/utils/deploy_platformsh.py
+++ b/simple_deploy/management/commands/utils/deploy_platformsh.py
@@ -273,10 +273,10 @@ class PlatformshDeployer:
         self.sd.commit_changes()
 
         # Push project.
+        # Use execute_command(), to stream the output as it runs.
         self.sd.write_output("  Pushing to Platform.sh...")
         cmd = "platform push --yes"
-        output = self.sd.execute_subp_run(cmd)
-        self.sd.write_output(output)
+        self.sd.execute_command(cmd)
 
         # Open project.
         self.sd.write_output("  Opening deployed app in a new browser tab...")


### PR DESCRIPTION
Stream the output of `platform push`, to allow users to better monitor that a push is still in progress and hasn't hung.