### PR TITLE
Update new readthedocs docs to address Platform.sh issues. Resolves #158

### DIFF
--- a/docs/platform_sh/quick_start.md
+++ b/docs/platform_sh/quick_start.md
@@ -19,7 +19,7 @@ Deployment to Platform.sh requires three things:
 
 - You must be using Git to track your project.
 - You need to have a `requirements.txt` file at the root of your project.
-- The [Platforms.h CLI](https://docs.platform.sh/development/cli.html) must be installed on your system.
+- The [Platform.sh CLI](https://docs.platform.sh/development/cli.html) must be installed on your system.
 
 ## Configuration-only deployment
 

--- a/docs/platform_sh/quick_start.md
+++ b/docs/platform_sh/quick_start.md
@@ -23,7 +23,14 @@ Deployment to Platform.sh requires three things:
 
 ## Configuration-only deployment
 
-First, install `django-simple-deploy`, and add `simple_deploy` to `INSTALLED_APPS` in *settings.py*:
+
+First, install `platformshconfig`. This package is used to determine whether local settings or Platform.sh-specific settings should be used:
+
+```
+$ pip install platformshconfig
+```
+
+Now, install `django-simple-deploy`, and add `simple_deploy` to `INSTALLED_APPS` in *settings.py*:
 
 ```
 $ pip install django-simple-deploy

--- a/simple_deploy/management/commands/utils/deploy_messages_flyio.py
+++ b/simple_deploy/management/commands/utils/deploy_messages_flyio.py
@@ -139,7 +139,7 @@ def success_msg(log_output=''):
             $ fly open    
         - As you develop your project further:
             - Make local changes
-            - Commmit your local changes
+            - Commit your local changes
             - Run `fly deploy`
     """)
 

--- a/simple_deploy/management/commands/utils/deploy_messages_platformsh.py
+++ b/simple_deploy/management/commands/utils/deploy_messages_platformsh.py
@@ -158,7 +158,7 @@ def success_msg(log_output=''):
             $ platform url    
         - As you develop your project further:
             - Make local changes
-            - Commmit your local changes
+            - Commit your local changes
             - Run `platform push`
     """)
 


### PR DESCRIPTION
* Include the `platformshconfig` pip dependency
* Smol spelling fixes. 

As discussed in #158