### PR TITLE
Fly csrf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 - Integration tests check that running simple_deploy does not affect local functionality using `runserver`.
     - Update configuration for Fly.io and Platform.sh to not interfere with local functionality using `runserver`.
 - Updated sample blog project to Django 4.1.2.
-    - Modified `test_deployed_app_functionality.py` to not require a trailing forward slash.    
+    - Modified `test_deployed_app_functionality.py` to not require a trailing forward slash.
+    - Added notes about the differences between nested and non-nested projects.
+- Deployments to Fly.io use the deployed project name in `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS` settings.
 
 ### 0.5.5
 

--- a/simple_deploy/templates/flyio_settings.py
+++ b/simple_deploy/templates/flyio_settings.py
@@ -23,4 +23,4 @@ if os.environ.get("ON_FLYIO"):
     DATABASES['default'] = dj_database_url.parse(db_url)
 
     # Prevent CSRF "Origin checking failed" issue.
-    CSRF_TRUSTED_ORIGINS = ['https://*.fly.dev']
+    CSRF_TRUSTED_ORIGINS = ['https://{{ deployed_project_name }}.fly.dev']

--- a/simple_deploy/templates/flyio_settings.py
+++ b/simple_deploy/templates/flyio_settings.py
@@ -21,3 +21,6 @@ if os.environ.get("ON_FLYIO"):
     # Use the Fly.io Postgres database.
     db_url = os.environ.get("DATABASE_URL")
     DATABASES['default'] = dj_database_url.parse(db_url)
+
+    # Prevent CSRF "Origin checking failed" issue.
+    CSRF_TRUSTED_ORIGINS = ['https://*.fly.dev']

--- a/simple_deploy/templates/flyio_settings.py
+++ b/simple_deploy/templates/flyio_settings.py
@@ -16,7 +16,7 @@ if os.environ.get("ON_FLYIO"):
     # Set a Fly.io-specific allowed host.
     # ALLOWED_HOSTS.append('{{ deployed_project_name }}.fly.dev')
     # Using '*' while further troubleshooting CSRF issue.
-    ALLOWED_HOSTS.append('*')
+    ALLOWED_HOSTS.append('{{ deployed_project_name }}.fly.dev')
 
     # Use the Fly.io Postgres database.
     db_url = os.environ.get("DATABASE_URL")


### PR DESCRIPTION
This addresses intermittent but persistent issues with "Origin checking failed" errors due to the changes in 4.0 regarding CSRF checks, when deploying to Fly.io. See #163. Also includes a more specific `ALLOWED_HOSTS` setting as well.