### PR TITLE
In test setup, configure git to always use `main` as default branch

### DIFF
--- a/unit_tests/utils/setup_project.sh
+++ b/unit_tests/utils/setup_project.sh
@@ -32,6 +32,9 @@ pip install -e "$sd_root_dir/"
 # Make it easier to verify what was installed when developing this script.
 pip freeze > installed_packages.txt
 
+# Make sure the default branch is main.
+git config --global init.defaultBranch main
+
 # Make an initial commit.
 git init
 git add .

--- a/unit_tests/utils/setup_project.sh
+++ b/unit_tests/utils/setup_project.sh
@@ -32,11 +32,9 @@ pip install -e "$sd_root_dir/"
 # Make it easier to verify what was installed when developing this script.
 pip freeze > installed_packages.txt
 
-# Make sure the default branch is main.
-git config --global init.defaultBranch main
-
 # Make an initial commit.
 git init
+git branch -m main
 git add .
 git commit -am "Initial commit."
 git tag -am '' INITIAL_STATE


### PR DESCRIPTION
I've had some issues running the platform agnostic tests, where the default branch in the CI environment is set as `master`:

```python
__________________________ test_invalid_platform_call __________________________

tmp_project = PosixPath('/Users/runner/work/django-simple-deploy/django-simple-deploy/unit_tests/dsd_temp/blog_project0')
capfd = <_pytest.capture.CaptureFixture object at 0x107c87580>

    def test_invalid_platform_call(tmp_project, capfd):
        """Call simple_deploy with an invalid --platform argument."""
        invalid_sd_command = "python manage.py simple_deploy --platform unsupported_platform_name"
    
        make_invalid_call(tmp_project, invalid_sd_command)
        captured = capfd.readouterr()
    
        assert "The platform unsupported_platform_name is not currently supported." in captured.err
>       check_project_unchanged(tmp_project, capfd)

platform_agnostic_tests/test_invalid_cli_commands.py:102: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

tmp_proj_dir = PosixPath('/Users/runner/work/django-simple-deploy/django-simple-deploy/unit_tests/dsd_temp/blog_project0')
capfd = <_pytest.capture.CaptureFixture object at 0x107c87580>

    def check_project_unchanged(tmp_proj_dir, capfd):
        """Check that the project has not been changed."""
        call_git_status(tmp_proj_dir)
        captured = capfd.readouterr()
>       assert "On branch main\nnothing to commit, working tree clean" in captured.out
E       AssertionError: assert 'On branch main\nnothing to commit, working tree clean' in 'On branch master\nnothing to commit, working tree clean\n'
E        +  where 'On branch master\nnothing to commit, working tree clean\n' = CaptureResult(out='On branch master\nnothing to commit, working tree clean\n', err='').out
```