### PR TITLE
Update docs config mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/support_new_platform.yml
+++ b/.github/ISSUE_TEMPLATE/support_new_platform.yml
@@ -48,7 +48,7 @@ body:
   - type: textarea
     attributes:
       label: "Quick Start: Configuration-only deployment"
-      description: What would the configuration-only deployment process look like for this platform? Please write this as a bulleted list, or as a series of commands like you see in the Fly.io Quick Start guide. Please mention any prerequisites for deployment to this platform as well.
+      description: What would the configuration-only deployment process look like for this platform? Please write this as a bulleted list, or as a series of commands like you see in the Fly.io Quick Start guide. Please mention any prerequisites for deployment to this platform as well. (In the configuration mode, you may have to create some resources on the user's behalf in order to carry out the configuration. The goal is to *only* create resources that we can't easily ask the user to create before running `simple_deploy`.)
 
   - type: textarea
     attributes:

--- a/docs/general_documentation/cli_reference.md
+++ b/docs/general_documentation/cli_reference.md
@@ -64,7 +64,7 @@ There are several options to customize `simple_deploy`'s behavior. You can autom
 
 ### `--automate-all`
 
-The recommended way to use `simple_deploy` is in configuration mode. In this mode, `simple_deploy` makes all configuration changes necessary to successfully deploy your project on the given platform. However, it does not commit these changes, it does not create any resources on your behalf, and it doesn not commit any changes. This is good, because it lets you know exactly what you need to create, and you get to review all changes before committing them to your project.
+The recommended (default) way to use `simple_deploy` is in configuration mode. In this mode, `simple_deploy` makes all configuration changes necessary to successfully deploy your project on the given platform. However, it avoids creating any remote resources it doesn't have to, and it does not any commits on your behalf. This is good, because it lets you know exactly what you need to create, and you get to review all changes before committing them to your project.
 
 The `--automate-all` flag tells `simple_deploy` to do everything for you: it creates any resources necessary for deployment on the target platform. It makes all the necessary configuration changes, and makes a new commit for these changes. Finally, it calls your platform's `push` or `deploy` command; you get to sit back and watch your deployed project appear in a new browser tab.
 


### PR DESCRIPTION
Clarify language around the difference between the default configuration-only mode, and the automate-all mode.