### PR TITLE
Specify equivalency of `fly` & `flyctl`

### DIFF
--- a/docs/quick_starts/quick_start_flyio.md
+++ b/docs/quick_starts/quick_start_flyio.md
@@ -32,6 +32,9 @@ $ pip install django-simple-deploy
 
 Now create a new Fly.io app using the CLI, and run `simple_deploy` to configure your app:
 
+!!! note
+    The `fly` and `flyctl` commands are used on the Fly.io docs interchangeably, we will be using `fly` here.
+
 ```
 $ fly apps create --generate-name
 $ python manage.py simple_deploy --platform fly_io


### PR DESCRIPTION
Getting started during pycon 2023 sprints.
This confused me when digging into Fly.io's docs, occasionally they use `flyctl`[^0][^1], but they've signalled that they prefer `fly`[^2].

![image](https://user-images.githubusercontent.com/17185986/234101386-2982d79c-dcd2-4880-9da1-408592c7bbe3.png)

[^0]: https://github.com/superfly/flyctl/blob/82e5a6aeb280dae03f716a5f58ebae1f2db24e11/README.md
[^1]: https://fly.io/blog/command-lines-flyctl-and-fly/
[^2]: https://community.fly.io/t/whats-the-difference-between-fly-and-flyctl/1377

See: #215