### PR TITLE
chore: add virtualenv dir to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ docs/tmp_header.md
 # Using pip to install from a local directory leaves a build/ dir in the root of this
 #   project. Ignore this, in case it's not destroyed properly after testing.
 build/
+
+# Ignores the virtualenv directory
+dsd_env
+.venv/


### PR DESCRIPTION
Currently, the project's `.gitignore` file doesn't ignore the local virtual environment directory, making `git` track dependencies changes:

<img width="520" alt="Screenshot 2023-04-25 at 11 29 29" src="https://user-images.githubusercontent.com/60162544/234355921-5ed17c11-97ce-407a-9fc9-c70542165978.png">

Which leads to crowded source control code changes:

<img width="425" alt="Screenshot 2023-04-25 at 11 29 52" src="https://user-images.githubusercontent.com/60162544/234356027-749c5414-16cb-469e-9eb9-706da8eddf1a.png">

[According to the official docs](https://django-simple-deploy.readthedocs.io/en/latest/contributing/development_environment/#make-a-local-working-copy-of-the-project), the contributor's virtual environment would be named `dsd_env`. Also, it's good practice to call the local virtual environment `.venv`. This way, both directory names were ignored (added to `.gitignore`).
