### PR TITLE
Minor adjustments to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-django-simple-deploy
-===
+# django-simple-deploy
+
 
 The full documentation for this project is at [Read the Docs](https://django-simple-deploy.readthedocs.io/en/latest/).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # django-simple-deploy
 
+Initial Django deployments made easy.
+
 
 The full documentation for this project is at [Read the Docs](https://django-simple-deploy.readthedocs.io/en/latest/).
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ If you have a relatively simple Django project that runs locally, you can deploy
 
 The above command will deploy your project to Heroku. To deploy to another platform such as Platform.sh, just change the `--platform` argument:
 
-```
-$ python manage.py simple_deploy --platform platform_sh
+```sh
+python manage.py simple_deploy --platform platform_sh
 ```
 
 All output is captured and written to a log file stored in `simple_deploy_logs/`, which is placed at the project's root directory.
-

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 Initial Django deployments made easy.
 
+## Documentation
 
 The full documentation for this project is at [Read the Docs](https://django-simple-deploy.readthedocs.io/en/latest/).
 
 Some documentation has not been moved to Read the Docs yet. You may find what you're looking for in the `old_docs/` directory, but some of that information is out of date.
 
-*Initial Django deployments made easy*
+## Quickstart
 
 This app gives you a management command that configures your project for an initial deployment. It targets [Fly.io](https://fly.io), [Platform.sh](https://platform.sh), and [Heroku](https://heroku.com) at the moment, and can be expanded to target other platforms as well.
 


### PR DESCRIPTION
Makes some adjustments to the base `README.md` to lint and format the document according to general Markdown specifications and highlight that newcomers should go to [ReadTheDocs](https://django-simple-deploy.readthedocs.io/en/latest/) for project documentation.