### PR TITLE
Add a pytest CLI flag to automatically open the test project after the tests finish.

### DIFF
--- a/docs/unit_tests/running_unit_tests.md
+++ b/docs/unit_tests/running_unit_tests.md
@@ -96,6 +96,8 @@ This output shows you where to find the test project, in this case `blog_project
 
 One great place to look when troubleshooting unit test runs is the test project's *simple_deploy_logs/* directory. The log should show you exactly what simple_deploy did to the test project during that test run.
 
+On macOS, you can tell pytest to automatically open a terminal window at the test project location after the test suite ends: `pytest -x --open-test-project` This flag opens a new terminal tab or window, activates the virtual environment, and shows the output of `git log --pretty=oneline`. You can explore the project, run simple_deploy commands, and look at the simple_deploy logs as well. This is an experimental feature.
+
 ## Helpful pytest notes
 
 If you're new to using pytest, here are some useful notes. (If you have any suggestions for what else to include here, please feel free to share them.)
@@ -103,6 +105,8 @@ If you're new to using pytest, here are some useful notes. (If you have any sugg
 - `pytest -x`
     - This is identical to `pytest --exitfirst`, which stops after the first failing test. This is especially helpful when diagnosing unit test failures.
     - A number of ways to run `pytest` are described in [How to invoke pytest](https://docs.pytest.org/en/latest/how-to/usage.html).
+- `pytest -s`
+    - Show output instead of capturing it.
 - `pytest -k`
     - Run a single test, or a test matching a pattern.
     - For example, if you want to run the test for the `pyproject.toml` file on Fly.io, you can use the following command: `$ pytest -k platforms/fly_io test_pyproject_toml`. This will actually run any test in the module that has that phrase in its name, but practically this is an effective way to isolate tests.

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -25,8 +25,10 @@ def pytest_sessionfinish(session, exitstatus):
     if session.config.getoption("--open-test-project"):
         # DEV: How can we identify the terminal environment where
         #   pytest is currently running?
+        tmp_proj_dir = session.config.cache.get("tmp_proj_dir", ".")
+
         if sys.platform == 'darwin':  # macOS
-            command = ['open', '-a', 'Terminal', '.']
+            command = ['open', '-a', 'Terminal', tmp_proj_dir]
         else:
             print("Unsupported platform")
             return
@@ -45,7 +47,7 @@ def check_prerequisites():
 
 
 @pytest.fixture(scope='session')
-def tmp_project(tmp_path_factory):
+def tmp_project(tmp_path_factory, pytestconfig):
     """Create a copy of the local sample project, so that platform-specific modules
     can call simple_deploy.
 
@@ -66,6 +68,10 @@ def tmp_project(tmp_path_factory):
     
     # Copy sample project to tmp dir, and set up the project for using simple_deploy.
     msp.setup_project(tmp_proj_dir, sd_root_dir)
+
+    # Store the tmp_proj_dir in the pytest cache, so we can access it in the
+    #   open_test_project() plugin.
+    pytestconfig.cache.set("tmp_proj_dir", str(tmp_proj_dir))
 
     # Return the location of the temp project.
     return tmp_proj_dir

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -33,11 +33,13 @@ def pytest_sessionfinish(session, exitstatus):
 
         tmp_proj_dir = session.config.cache.get("tmp_proj_dir", ".")
 
+        # DEV: This might be good enough; it just drops you into a terminal
+        #   window at the temp project. You have to activate the venv.
         # cmd = f'open -a Terminal {tmp_proj_dir}'
         # subprocess.run(cmd.split())
 
 
-        # Create the shell script with the commands you want to run
+        # This is a list of all the commands we want to run in the temp directory.
         shell_script = f"""
         #!/bin/bash
         cd {tmp_proj_dir}
@@ -46,30 +48,18 @@ def pytest_sessionfinish(session, exitstatus):
         git log --pretty=oneline
         bash
         """
-        # Write the script to a temporary file
+
+        # Write the script to a temporary file.
+        # DEV: Not ideal, because it affects output of `git status`.
         with open(f"{tmp_proj_dir}/commands.sh", "w") as script_file:
             script_file.write(shell_script)
 
-        # Make the script executable
+        # Make the script executable.
         os.chmod(f"{tmp_proj_dir}/commands.sh", 0o755)
 
         # Open a new terminal and run the script
         cmd = f'open -a Terminal {tmp_proj_dir}/commands.sh'
         subprocess.run(cmd.split())
-
-
-
-        # os.chdir(tmp_proj_dir)
-        # venv_dir = tmp_proj_dir / "b_env"
-        # cmd = f"source {venv_dir}/bin/activate"
-
-
-
-        # cmd = 'source b_env/bin/activate'
-        # cmd = 'git status'
-        # subprocess.run(cmd.split())
-
-
 
 # --- /Plugins ---
 

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1,4 +1,4 @@
-import subprocess, re, sys
+import subprocess, re, sys, tempfile
 from pathlib import Path
 from time import sleep
 
@@ -50,15 +50,16 @@ def pytest_sessionfinish(session, exitstatus):
         """
 
         # Write the script to a temporary file.
-        # DEV: Not ideal, because it affects output of `git status`.
-        with open(f"{tmp_proj_dir}/commands.sh", "w") as script_file:
+        #   Don't write this in tmp_proj_dir, as that would affect git status.
+        script_dir = tempfile.gettempdir()
+        with open(f"{script_dir}/commands.sh", "w") as script_file:
             script_file.write(shell_script)
 
         # Make the script executable.
-        os.chmod(f"{tmp_proj_dir}/commands.sh", 0o755)
+        os.chmod(f"{script_dir}/commands.sh", 0o755)
 
         # Open a new terminal and run the script
-        cmd = f'open -a Terminal {tmp_proj_dir}/commands.sh'
+        cmd = f'open -a Terminal {script_dir}/commands.sh'
         subprocess.run(cmd.split())
 
 # --- /Plugins ---

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -25,15 +25,51 @@ def pytest_sessionfinish(session, exitstatus):
     if session.config.getoption("--open-test-project"):
         # DEV: How can we identify the terminal environment where
         #   pytest is currently running?
-        tmp_proj_dir = session.config.cache.get("tmp_proj_dir", ".")
 
-        if sys.platform == 'darwin':  # macOS
-            command = ['open', '-a', 'Terminal', tmp_proj_dir]
-        else:
-            print("Unsupported platform")
+        # Currently, this plugin only supports macOS.
+        if sys.platform != 'darwin':
+            print("The --open-test-project option is not yet supported on your platform.")
             return
 
-        subprocess.run(command)
+        tmp_proj_dir = session.config.cache.get("tmp_proj_dir", ".")
+
+        # cmd = f'open -a Terminal {tmp_proj_dir}'
+        # subprocess.run(cmd.split())
+
+
+        # Create the shell script with the commands you want to run
+        shell_script = f"""
+        #!/bin/bash
+        cd {tmp_proj_dir}
+        source b_env/bin/activate
+        git status
+        git log --pretty=oneline
+        bash
+        """
+        # Write the script to a temporary file
+        with open(f"{tmp_proj_dir}/commands.sh", "w") as script_file:
+            script_file.write(shell_script)
+
+        # Make the script executable
+        os.chmod(f"{tmp_proj_dir}/commands.sh", 0o755)
+
+        # Open a new terminal and run the script
+        cmd = f'open -a Terminal {tmp_proj_dir}/commands.sh'
+        subprocess.run(cmd.split())
+
+
+
+        # os.chdir(tmp_proj_dir)
+        # venv_dir = tmp_proj_dir / "b_env"
+        # cmd = f"source {venv_dir}/bin/activate"
+
+
+
+        # cmd = 'source b_env/bin/activate'
+        # cmd = 'git status'
+        # subprocess.run(cmd.split())
+
+
 
 # --- /Plugins ---
 

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -11,6 +11,11 @@ from .utils import ut_helper_functions as uhf
 # --- Plugins ---
 
 import os
+# I tried putting this in a unit_tests/plugins/ dir, but could not get it to load.
+#   The only thing that worked was:
+#   $ PYTHONPATH=../ pytest -x --open-test-project
+# I tried setting pythonpath in pytest.ini, and unit_tests/ was added to the path,
+#   but it still couldn't find the plugin.
 
 def pytest_addoption(parser):
     parser.addoption("--open-test-project", action="store_true",

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -8,6 +8,29 @@ from .utils import manage_sample_project as msp
 from .utils import ut_helper_functions as uhf
 
 
+# --- Plugins ---
+
+import os
+
+def pytest_addoption(parser):
+    parser.addoption("--open-test-project", action="store_true",
+        help="Open the test project in an active terminal window at the end of the test run")
+
+def pytest_sessionfinish(session, exitstatus):
+    if session.config.getoption("--open-test-project"):
+        # DEV: How can we identify the terminal environment where
+        #   pytest is currently running?
+        if sys.platform == 'darwin':  # macOS
+            command = ['open', '-a', 'Terminal', '.']
+        else:
+            print("Unsupported platform")
+            return
+
+        subprocess.run(command)
+
+# --- /Plugins ---
+
+
 # Check prerequisites before running unit tests.
 @pytest.fixture(scope='session', autouse=True)
 def check_prerequisites():

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -35,12 +35,9 @@ def pytest_sessionfinish(session, exitstatus):
 
         tmp_proj_dir = session.config.cache.get("tmp_proj_dir", ".")
 
-        # DEV: This might be good enough; it just drops you into a terminal
-        #   window at the temp project. You have to activate the venv.
-        # cmd = f'open -a Terminal {tmp_proj_dir}'
-        # subprocess.run(cmd.split())
-
-        # This is a list of all the commands we want to run in the temp directory.
+        # Write a script containing all the commands we need to set up
+        #   a terminal environment for exploring the test project in its
+        #   final state.
         shell_script = f"""
         #!/bin/bash
         cd {tmp_proj_dir}

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -10,8 +10,9 @@ from .utils import ut_helper_functions as uhf
 
 # --- Plugins ---
 
-# Trying to make a plugin to be able to run `pytest -x -p --open-test-project`
+# Trying to make a plugin to be able to run `pytest -x -p open-test-project`
 #   See: https://github.com/ehmatthes/django-simple-deploy/issues/240
+#   Currently works: `pytest -x --open-test-project`
 # 
 # I tried putting this in a unit_tests/plugins/ dir, but could not get it to load.
 #   The only thing that worked was:

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1,4 +1,4 @@
-import subprocess, re, sys, tempfile
+import subprocess, re, sys, os, tempfile
 from pathlib import Path
 from time import sleep
 
@@ -10,7 +10,9 @@ from .utils import ut_helper_functions as uhf
 
 # --- Plugins ---
 
-import os
+# Trying to make a plugin to be able to run `pytest -x -p --open-test-project`
+#   See: https://github.com/ehmatthes/django-simple-deploy/issues/240
+# 
 # I tried putting this in a unit_tests/plugins/ dir, but could not get it to load.
 #   The only thing that worked was:
 #   $ PYTHONPATH=../ pytest -x --open-test-project
@@ -53,8 +55,8 @@ def pytest_sessionfinish(session, exitstatus):
         # Write the script to a temporary file.
         #   Don't write this in tmp_proj_dir, as that would affect git status.
         script_dir = tempfile.gettempdir()
-        with open(f"{script_dir}/commands.sh", "w") as script_file:
-            script_file.write(shell_script)
+        path = Path(f"{script_dir}/commands.sh")
+        path.write_text(shell_script)
 
         # Make the script executable.
         os.chmod(f"{script_dir}/commands.sh", 0o755)

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -38,14 +38,15 @@ def pytest_sessionfinish(session, exitstatus):
         # cmd = f'open -a Terminal {tmp_proj_dir}'
         # subprocess.run(cmd.split())
 
-
         # This is a list of all the commands we want to run in the temp directory.
         shell_script = f"""
         #!/bin/bash
         cd {tmp_proj_dir}
+        export PS1="\W$ "
         source b_env/bin/activate
         git status
         git log --pretty=oneline
+        echo "\n--- Feel free to poke around the temp test project! ---"
         bash
         """
 

--- a/unit_tests/platforms/heroku/reference_files/poetry.requirements.txt
+++ b/unit_tests/platforms/heroku/reference_files/poetry.requirements.txt
@@ -1,13 +1,14 @@
-asgiref==3.6.0 ; python_version >= "3.9" and python_version < "4.0"
-certifi==2022.12.7 ; python_version >= "3.9" and python_version < "4.0"
+asgiref==3.7.2 ; python_version >= "3.9" and python_version < "4.0"
+certifi==2023.5.7 ; python_version >= "3.9" and python_version < "4.0"
 charset-normalizer==3.1.0 ; python_version >= "3.9" and python_version < "4.0"
-django-bootstrap5==23.1 ; python_version >= "3.9" and python_version < "4.0"
-django==4.2 ; python_version >= "3.9" and python_version < "4.0"
+django-bootstrap5==23.3 ; python_version >= "3.9" and python_version < "4.0"
+django==4.2.2 ; python_version >= "3.9" and python_version < "4.0"
 idna==3.4 ; python_version >= "3.9" and python_version < "4.0"
-requests==2.29.0 ; python_version >= "3.9" and python_version < "4.0"
+requests==2.31.0 ; python_version >= "3.9" and python_version < "4.0"
 sqlparse==0.4.4 ; python_version >= "3.9" and python_version < "4.0"
+typing-extensions==4.6.3 ; python_version >= "3.9" and python_version < "3.11"
 tzdata==2023.3 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "win32"
-urllib3==1.26.15 ; python_version >= "3.9" and python_version < "4.0"
+urllib3==2.0.3 ; python_version >= "3.9" and python_version < "4.0"
 
 django-simple-deploy          # Added by simple_deploy command.
 gunicorn                      # Added by simple_deploy command.


### PR DESCRIPTION
It's often useful to explore the test project after a test run. This flag makes it easy to do that. The test project is in a new location after every test run, so this flag saves a lot of terminal and file explorer navigation.