### PR TITLE
Fix code blocks

### DIFF
--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -95,9 +95,9 @@ The [standalone test project](https://github.com/ehmatthes/dsd_sample_blog_reqtx
 
 Clone the test repo to a directory outside of the `django-simple-deploy/` directory:
 
-    ```sh
-    $ git clone https://github.com/ehmatthes/dsd_sample_blog_reqtxt.git
-    ```
+```sh
+$ git clone https://github.com/ehmatthes/dsd_sample_blog_reqtxt.git
+```
 
 ## Make sure the test project works
 
@@ -161,10 +161,10 @@ If the tests pass, you're ready to run a deployment using your local version of 
 
 Before you run `simple_deploy`, make a commit so you can more easily do repeated deployments without having to build the test project from scratch:
 
-    ```sh
-    $ git add .
-    $ git commit -am "Initial state, before using simple_deploy."
-    ```
+```sh
+$ git add .
+$ git commit -am "Initial state, before using simple_deploy."
+```
 
 ## Make an editable install of `django-simple-deploy`
 
@@ -172,9 +172,9 @@ To use your local version of `django-simple-deploy`, we'll install `simple_deplo
 
 Here's how to make the editable install:
 
-    ```sh
-    $ python -m pip install -e /local/path/to/django-simple-deploy/
-    ```
+```sh
+$ python -m pip install -e /local/path/to/django-simple-deploy/
+```
 
 ## Run `simple_deploy` against the test project
 
@@ -184,9 +184,9 @@ Now, visit the [Quick Start](../quick_starts/index.md) page for the platform you
 
 To make sure the deployment worked, run the functionality tests against the deployed version of the sample project:
 
-    ```sh
-    $ python test_deployed_app_functionality.py --url https://deployed-project-url
-    ```
+```sh
+$ python test_deployed_app_functionality.py --url https://deployed-project-url
+```
 
 Keep in mind that the `--flush-db` command will not work on a deployed project. Also, note that these automated tests don't always work on projects that are deployed using the lowest-tier resources on the target platform. If you see the deployed site in the browser but the tests fail, try clicking through different pages and making a user account. It's possible that the project works for manual use, but doesn't respond well to rapid automated test requests.
 
@@ -208,18 +208,18 @@ Now you're ready to do your own development work on `simple_deploy`. Make a new 
 
 The `--unit-testing` and `--ignore-unclean-git` flags can be really helpful when doing development work. For example say you're revising the approach to generating a dockerfile for Poetry users when deploying to Fly.io. You've modified some of the project's code, and you want to see how it impacts your demo project. Run the following command:
 
-    ```sh
-    $ python manage.py simple_deploy --platform fly_io --unit-testing
-    ```
+```sh
+$ python manage.py simple_deploy --platform fly_io --unit-testing
+```
 
 This won't run the unit tests, but it will skip the same network calls that are skipped during unit testing. You should see most of the same configuration that's done during a normal run, using sample resource names.
 
 When you've made more changes and want to run `simple_deploy` again, but all you're interested in is the Dockerfile that's generated, run the following two commands:
 
-    ```sh
-    $ rm Dockerfile
-    $ python manage.py simple_deploy --platform fly_io --unit-testing --ignore-unclean-git
-    ```
+```sh
+$ rm Dockerfile
+$ python manage.py simple_deploy --platform fly_io --unit-testing --ignore-unclean-git
+```
 
 This will avoid network calls and use sample resource names again, and it will ignore the fact that you have significant uncommitted changes. A new Dockerfile should be generated, and you can repeat these steps to rapidly develop the code that generates the Dockerfile.
 

--- a/docs/contributing/test_run.md
+++ b/docs/contributing/test_run.md
@@ -80,15 +80,15 @@ At this point you may want to visit the site and make an account, and maybe make
 
 The functionality tests use `requests`; these are not typical tests for a Django project. They're written this way to facilitate testing deployed versions of the project, as a user would interact with them. You can run these tests against the local project if you want. Open a new terminal tab, activate the virtual environment, and run the following command:
 
-    ```sh
-    (b_env)$ python test_deployed_app_functionality.py --url http://localhost:8000
-    ```
+```sh
+(b_env)$ python test_deployed_app_functionality.py --url http://localhost:8000
+```
 
 The tests are meant to be run against a freshly-deployed version of the project, with no user data. If you get errors, you may need to rerun the tests using the `--flush-db` flag, which only works when testing the local version of the project:
 
-    ```sh
-    (b_env)$ python test_deployed_app_functionality.py --flush-db --url http://localhost:8000
-    ```
+```sh
+(b_env)$ python test_deployed_app_functionality.py --flush-db --url http://localhost:8000
+```
 
 ### Run `simple_deploy` against the sample project
 
@@ -102,9 +102,9 @@ If the deployment was not successful, please provide as much information as you 
 
 If the deployment was successful, you can run the automated tests against the deployed project. Remember that `--flush-db` won't work on the deployed project, so consider running these tests before entering any data on the deployed site. To run the tests:
 
-    ```sh
-    (b_env)$ python test_deployed_app_functionality.py --url https://deployed-project-url
-    ```
+```sh
+(b_env)$ python test_deployed_app_functionality.py --url https://deployed-project-url
+```
 
 After running the tests, poke around the site on your own as well. Make sure you can make an account, make a blog and a post, and visit the admin site. (You'll need to make a superuser account on your own; `django-simple-deploy` does not do this for you.)
 


### PR DESCRIPTION
Fixes #251
Closes #252 

The problem was the code blocks where fenced _and_ indented, which is required when showing multiplatform examples, but not in these cases.