### PR TITLE
Stabilize deployments on Fly.io

### DIFF
--- a/developer_resources/platforms/fly_io/fly_apps_list_one_app_deployed.json
+++ b/developer_resources/platforms/fly_io/fly_apps_list_one_app_deployed.json
@@ -1,0 +1,422 @@
+[
+    {
+        "ID": "dry-sunset-9033",
+        "Name": "dry-sunset-9033",
+        "State": "",
+        "Status": "deployed",
+        "Deployed": true,
+        "Hostname": "dry-sunset-9033.fly.dev",
+        "AppURL": "",
+        "Version": 0,
+        "NetworkID": 0,
+        "Release": null,
+        "Organization": {
+            "ID": "",
+            "InternalNumericID": "",
+            "Name": "Eric Matthes",
+            "RemoteBuilderImage": "",
+            "RemoteBuilderApp": null,
+            "Slug": "personal",
+            "RawSlug": "",
+            "Type": "",
+            "PaidPlan": false,
+            "Settings": null,
+            "Domains": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "WireGuardPeer": null,
+            "WireGuardPeers": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "DelegatedWireGuardTokens": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "HealthCheckHandlers": null,
+            "HealthChecks": null,
+            "LoggedCertificates": null,
+            "LimitedAccessTokens": null
+        },
+        "Secrets": null,
+        "CurrentRelease": {
+            "ID": "",
+            "Version": 0,
+            "Stable": false,
+            "InProgress": false,
+            "Reason": "",
+            "Description": "",
+            "Status": "complete",
+            "DeploymentStrategy": "",
+            "User": {
+                "ID": "",
+                "Name": "",
+                "Email": "",
+                "EnablePaidHobby": false
+            },
+            "EvaluationID": "",
+            "CreatedAt": "2023-11-30T21:01:20Z",
+            "ImageRef": ""
+        },
+        "Releases": {
+            "Nodes": null
+        },
+        "IPAddresses": {
+            "Nodes": null
+        },
+        "SharedIPAddress": "",
+        "IPAddress": null,
+        "Builds": {
+            "Nodes": null
+        },
+        "SourceBuilds": {
+            "Nodes": null
+        },
+        "Changes": {
+            "Nodes": null
+        },
+        "Certificates": {
+            "Nodes": null
+        },
+        "Certificate": {
+            "ID": "",
+            "AcmeDNSConfigured": false,
+            "AcmeALPNConfigured": false,
+            "Configured": false,
+            "CertificateAuthority": "",
+            "CreatedAt": "0001-01-01T00:00:00Z",
+            "DNSProvider": "",
+            "DNSValidationInstructions": "",
+            "DNSValidationHostname": "",
+            "DNSValidationTarget": "",
+            "Hostname": "",
+            "Source": "",
+            "ClientStatus": "",
+            "IsApex": false,
+            "IsWildcard": false,
+            "Issued": {
+                "Nodes": null
+            }
+        },
+        "Config": {
+            "Definition": null,
+            "Services": null,
+            "Valid": false,
+            "Errors": null
+        },
+        "ParseConfig": {
+            "Definition": null,
+            "Services": null,
+            "Valid": false,
+            "Errors": null
+        },
+        "Allocations": null,
+        "Allocation": null,
+        "DeploymentStatus": null,
+        "Autoscaling": null,
+        "VMSize": {
+            "Name": "",
+            "CPUCores": 0,
+            "CPUClass": "",
+            "MemoryGB": 0,
+            "MemoryMB": 0,
+            "PriceMonth": 0,
+            "PriceSecond": 0
+        },
+        "Regions": null,
+        "BackupRegions": null,
+        "TaskGroupCounts": null,
+        "ProcessGroups": null,
+        "HealthChecks": null,
+        "PostgresAppRole": null,
+        "Image": null,
+        "ImageUpgradeAvailable": false,
+        "ImageVersionTrackingEnabled": false,
+        "ImageDetails": {
+            "Registry": "",
+            "Repository": "",
+            "Tag": "",
+            "Version": "",
+            "Digest": ""
+        },
+        "LatestImageDetails": {
+            "Registry": "",
+            "Repository": "",
+            "Tag": "",
+            "Version": "",
+            "Digest": ""
+        },
+        "PlatformVersion": "machines",
+        "LimitedAccessTokens": null,
+        "CurrentLock": null
+    },
+    {
+        "ID": "dry-sunset-9033-db",
+        "Name": "dry-sunset-9033-db",
+        "State": "",
+        "Status": "deployed",
+        "Deployed": true,
+        "Hostname": "dry-sunset-9033-db.fly.dev",
+        "AppURL": "",
+        "Version": 0,
+        "NetworkID": 0,
+        "Release": null,
+        "Organization": {
+            "ID": "",
+            "InternalNumericID": "",
+            "Name": "Eric Matthes",
+            "RemoteBuilderImage": "",
+            "RemoteBuilderApp": null,
+            "Slug": "personal",
+            "RawSlug": "",
+            "Type": "",
+            "PaidPlan": false,
+            "Settings": null,
+            "Domains": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "WireGuardPeer": null,
+            "WireGuardPeers": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "DelegatedWireGuardTokens": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "HealthCheckHandlers": null,
+            "HealthChecks": null,
+            "LoggedCertificates": null,
+            "LimitedAccessTokens": null
+        },
+        "Secrets": null,
+        "CurrentRelease": null,
+        "Releases": {
+            "Nodes": null
+        },
+        "IPAddresses": {
+            "Nodes": null
+        },
+        "SharedIPAddress": "",
+        "IPAddress": null,
+        "Builds": {
+            "Nodes": null
+        },
+        "SourceBuilds": {
+            "Nodes": null
+        },
+        "Changes": {
+            "Nodes": null
+        },
+        "Certificates": {
+            "Nodes": null
+        },
+        "Certificate": {
+            "ID": "",
+            "AcmeDNSConfigured": false,
+            "AcmeALPNConfigured": false,
+            "Configured": false,
+            "CertificateAuthority": "",
+            "CreatedAt": "0001-01-01T00:00:00Z",
+            "DNSProvider": "",
+            "DNSValidationInstructions": "",
+            "DNSValidationHostname": "",
+            "DNSValidationTarget": "",
+            "Hostname": "",
+            "Source": "",
+            "ClientStatus": "",
+            "IsApex": false,
+            "IsWildcard": false,
+            "Issued": {
+                "Nodes": null
+            }
+        },
+        "Config": {
+            "Definition": null,
+            "Services": null,
+            "Valid": false,
+            "Errors": null
+        },
+        "ParseConfig": {
+            "Definition": null,
+            "Services": null,
+            "Valid": false,
+            "Errors": null
+        },
+        "Allocations": null,
+        "Allocation": null,
+        "DeploymentStatus": null,
+        "Autoscaling": null,
+        "VMSize": {
+            "Name": "",
+            "CPUCores": 0,
+            "CPUClass": "",
+            "MemoryGB": 0,
+            "MemoryMB": 0,
+            "PriceMonth": 0,
+            "PriceSecond": 0
+        },
+        "Regions": null,
+        "BackupRegions": null,
+        "TaskGroupCounts": null,
+        "ProcessGroups": null,
+        "HealthChecks": null,
+        "PostgresAppRole": null,
+        "Image": null,
+        "ImageUpgradeAvailable": false,
+        "ImageVersionTrackingEnabled": false,
+        "ImageDetails": {
+            "Registry": "",
+            "Repository": "",
+            "Tag": "",
+            "Version": "",
+            "Digest": ""
+        },
+        "LatestImageDetails": {
+            "Registry": "",
+            "Repository": "",
+            "Tag": "",
+            "Version": "",
+            "Digest": ""
+        },
+        "PlatformVersion": "machines",
+        "LimitedAccessTokens": null,
+        "CurrentLock": null
+    },
+    {
+        "ID": "fly-builder-restless-mountain-4682",
+        "Name": "fly-builder-restless-mountain-4682",
+        "State": "",
+        "Status": "deployed",
+        "Deployed": true,
+        "Hostname": "fly-builder-restless-mountain-4682.fly.dev",
+        "AppURL": "",
+        "Version": 0,
+        "NetworkID": 0,
+        "Release": null,
+        "Organization": {
+            "ID": "",
+            "InternalNumericID": "",
+            "Name": "Eric Matthes",
+            "RemoteBuilderImage": "",
+            "RemoteBuilderApp": null,
+            "Slug": "personal",
+            "RawSlug": "",
+            "Type": "",
+            "PaidPlan": false,
+            "Settings": null,
+            "Domains": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "WireGuardPeer": null,
+            "WireGuardPeers": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "DelegatedWireGuardTokens": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "HealthCheckHandlers": null,
+            "HealthChecks": null,
+            "LoggedCertificates": null,
+            "LimitedAccessTokens": null
+        },
+        "Secrets": null,
+        "CurrentRelease": null,
+        "Releases": {
+            "Nodes": null
+        },
+        "IPAddresses": {
+            "Nodes": null
+        },
+        "SharedIPAddress": "",
+        "IPAddress": null,
+        "Builds": {
+            "Nodes": null
+        },
+        "SourceBuilds": {
+            "Nodes": null
+        },
+        "Changes": {
+            "Nodes": null
+        },
+        "Certificates": {
+            "Nodes": null
+        },
+        "Certificate": {
+            "ID": "",
+            "AcmeDNSConfigured": false,
+            "AcmeALPNConfigured": false,
+            "Configured": false,
+            "CertificateAuthority": "",
+            "CreatedAt": "0001-01-01T00:00:00Z",
+            "DNSProvider": "",
+            "DNSValidationInstructions": "",
+            "DNSValidationHostname": "",
+            "DNSValidationTarget": "",
+            "Hostname": "",
+            "Source": "",
+            "ClientStatus": "",
+            "IsApex": false,
+            "IsWildcard": false,
+            "Issued": {
+                "Nodes": null
+            }
+        },
+        "Config": {
+            "Definition": null,
+            "Services": null,
+            "Valid": false,
+            "Errors": null
+        },
+        "ParseConfig": {
+            "Definition": null,
+            "Services": null,
+            "Valid": false,
+            "Errors": null
+        },
+        "Allocations": null,
+        "Allocation": null,
+        "DeploymentStatus": null,
+        "Autoscaling": null,
+        "VMSize": {
+            "Name": "",
+            "CPUCores": 0,
+            "CPUClass": "",
+            "MemoryGB": 0,
+            "MemoryMB": 0,
+            "PriceMonth": 0,
+            "PriceSecond": 0
+        },
+        "Regions": null,
+        "BackupRegions": null,
+        "TaskGroupCounts": null,
+        "ProcessGroups": null,
+        "HealthChecks": null,
+        "PostgresAppRole": null,
+        "Image": null,
+        "ImageUpgradeAvailable": false,
+        "ImageVersionTrackingEnabled": false,
+        "ImageDetails": {
+            "Registry": "",
+            "Repository": "",
+            "Tag": "",
+            "Version": "",
+            "Digest": ""
+        },
+        "LatestImageDetails": {
+            "Registry": "",
+            "Repository": "",
+            "Tag": "",
+            "Version": "",
+            "Digest": ""
+        },
+        "PlatformVersion": "machines",
+        "LimitedAccessTokens": null,
+        "CurrentLock": null
+    }
+]

--- a/developer_resources/platforms/fly_io/fly_apps_list_one_app_not_deployed.json
+++ b/developer_resources/platforms/fly_io/fly_apps_list_one_app_not_deployed.json
@@ -1,0 +1,136 @@
+[
+    {
+        "ID": "black-feather-6028",
+        "Name": "black-feather-6028",
+        "State": "",
+        "Status": "pending",
+        "Deployed": false,
+        "Hostname": "black-feather-6028.fly.dev",
+        "AppURL": "",
+        "Version": 0,
+        "NetworkID": 0,
+        "Release": null,
+        "Organization": {
+            "ID": "",
+            "InternalNumericID": "",
+            "Name": "Eric Matthes",
+            "RemoteBuilderImage": "",
+            "RemoteBuilderApp": null,
+            "Slug": "personal",
+            "RawSlug": "",
+            "Type": "",
+            "PaidPlan": false,
+            "Settings": null,
+            "Domains": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "WireGuardPeer": null,
+            "WireGuardPeers": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "DelegatedWireGuardTokens": {
+                "Nodes": null,
+                "Edges": null
+            },
+            "HealthCheckHandlers": null,
+            "HealthChecks": null,
+            "LoggedCertificates": null,
+            "LimitedAccessTokens": null
+        },
+        "Secrets": null,
+        "CurrentRelease": null,
+        "Releases": {
+            "Nodes": null
+        },
+        "IPAddresses": {
+            "Nodes": null
+        },
+        "SharedIPAddress": "",
+        "IPAddress": null,
+        "Builds": {
+            "Nodes": null
+        },
+        "SourceBuilds": {
+            "Nodes": null
+        },
+        "Changes": {
+            "Nodes": null
+        },
+        "Certificates": {
+            "Nodes": null
+        },
+        "Certificate": {
+            "ID": "",
+            "AcmeDNSConfigured": false,
+            "AcmeALPNConfigured": false,
+            "Configured": false,
+            "CertificateAuthority": "",
+            "CreatedAt": "0001-01-01T00:00:00Z",
+            "DNSProvider": "",
+            "DNSValidationInstructions": "",
+            "DNSValidationHostname": "",
+            "DNSValidationTarget": "",
+            "Hostname": "",
+            "Source": "",
+            "ClientStatus": "",
+            "IsApex": false,
+            "IsWildcard": false,
+            "Issued": {
+                "Nodes": null
+            }
+        },
+        "Config": {
+            "Definition": null,
+            "Services": null,
+            "Valid": false,
+            "Errors": null
+        },
+        "ParseConfig": {
+            "Definition": null,
+            "Services": null,
+            "Valid": false,
+            "Errors": null
+        },
+        "Allocations": null,
+        "Allocation": null,
+        "DeploymentStatus": null,
+        "Autoscaling": null,
+        "VMSize": {
+            "Name": "",
+            "CPUCores": 0,
+            "CPUClass": "",
+            "MemoryGB": 0,
+            "MemoryMB": 0,
+            "PriceMonth": 0,
+            "PriceSecond": 0
+        },
+        "Regions": null,
+        "BackupRegions": null,
+        "TaskGroupCounts": null,
+        "ProcessGroups": null,
+        "HealthChecks": null,
+        "PostgresAppRole": null,
+        "Image": null,
+        "ImageUpgradeAvailable": false,
+        "ImageVersionTrackingEnabled": false,
+        "ImageDetails": {
+            "Registry": "",
+            "Repository": "",
+            "Tag": "",
+            "Version": "",
+            "Digest": ""
+        },
+        "LatestImageDetails": {
+            "Registry": "",
+            "Repository": "",
+            "Tag": "",
+            "Version": "",
+            "Digest": ""
+        },
+        "PlatformVersion": "machines",
+        "LimitedAccessTokens": null,
+        "CurrentLock": null
+    }
+]

--- a/docs/general_documentation/choosing_platform.md
+++ b/docs/general_documentation/choosing_platform.md
@@ -18,8 +18,8 @@ This page summarizes the major strengths and potential drawbacks of each platfor
 
 |                       | Fly.io             | Platform.sh             | Heroku                                                      |
 | --------------------- | ------------------ | ----------------------- | ----------------------------------------------------------- |
-| Credit Cards required for trial | Yes                | No                      | Yes, after [11/28/22](https://blog.heroku.com/next-chapter) |
-| Free trial length     | Unlimited time | 30 days | No free trial after 11/28/22 |
+| Credit Cards required for trial | Yes                | No                      | Yes |
+| Free trial length     | Unlimited time | 30 days | No free trial |
 | Cheapest paid plan    | $1.94/mo              | $10/mo                  | [$10/mo](https://blog.heroku.com/new-low-cost-plans) ($5 Eco dyno + $5 Mini Postgres)                     |
 | Company founded       | 2017               | 2012                    | 2007                                                        |
 
@@ -63,7 +63,7 @@ This page summarizes the major strengths and potential drawbacks of each platfor
     **Strengths**
 
     * Platform.sh does not require a credit card for its free trial.
-    * Once you have an environment set up with Platform.sh' tools, pushing a project and maintaining it is as straightforward as it is on any other comparable platform.
+    * Once you have an environment set up with the Platform.sh tools, pushing a project and maintaining it is as straightforward as it is on any other comparable platform.
 
 
     **Issues**
@@ -86,7 +86,7 @@ This page summarizes the major strengths and potential drawbacks of each platfor
 
     **Known for**
 
-    * Heroku was the original "Platform as a Service (PaaS)" provider. Heroku pioneered the simple `git push heroku main` deployment process that most other platforms are trying to build on today.
+    * Heroku was the original "Platform as a Service:" (PaaS) provider. Heroku pioneered the simple `git push heroku main` deployment process that most other platforms are trying to build on today.
     * Heroku is known for being more expensive than options such as VPS providers, and AWS. However, they quite reasonably argue that using Heroku requires less developer focus than unmanaged solutions like a VPS or AWS. You get to spend more of your time building your project, and less time acting as a sysadmin.
 
     **Strengths**
@@ -96,14 +96,14 @@ This page summarizes the major strengths and potential drawbacks of each platfor
     **Issues**
 
     * Heroku was a great platform in the late 2000s through the mid 2010s, but then it began to stagnate. Packages that were recommended for deployment were archived and unmaintained, even though they were officially still recommended. Heroku "just worked" for a long time, but recently that neglect has caught up to them. They are in the midst of restructuring their platform, and people are reasonably concerned about Heroku's long-term stability.
-    * Heroku has had major incidents and outages recently, which they took a long time to resolve and communicated poorly about. This is more significant reason many people have moved away from them in recent months.
-    * Heroku was famous for a very generous free tier, where you could deploy up to 5 apps at a time including a small Heroku Postgres database. This kind of offering sounds nice, but it also draws abuse. Heroku was constantly fighting things like auto-deployed crypto miners. They recently [announced the end of the free tier](https://blog.heroku.com/next-chapter). Their cheapest plans are still reasonably priced, though, so the end of the free tier should not rule them out as a hosting option.
+    * Heroku has had major incidents and outages in recent years, which they took a long time to resolve and communicated poorly about. This is the more significant reason many people have moved away from them in recent years.
+    * Heroku was famous for a very generous free tier, where you could deploy up to 5 apps at a time including a small Heroku Postgres database. This kind of offering sounds nice, but it also draws abuse. Heroku was constantly fighting things like auto-deployed crypto miners. They no longer offer a free tier. Their cheapest plans are still reasonably priced, though, so the end of the free tier should not rule them out as a hosting option.
 
     **Links**
 
     * [Heroku home page](https://www.heroku.com)
     * [Pricing](https://www.heroku.com/pricing)
-        * *Note: Heroku's lowest-priced tiers are in the process of being [restructured](https://blog.heroku.com/new-low-cost-plans).*
+        * *Note: Heroku's lowest-priced tiers were recently [restructured](https://blog.heroku.com/new-low-cost-plans).*
     * [Docs home page](https://devcenter.heroku.com)
     * [CLI installation](https://devcenter.heroku.com/articles/heroku-cli)
     * [CLI reference](https://devcenter.heroku.com/categories/command-line)

--- a/docs/quick_starts/quick_start_flyio.md
+++ b/docs/quick_starts/quick_start_flyio.md
@@ -8,7 +8,7 @@ hide:
 
 ## Overview
 
-Support for Fly.io is in a very preliminary phase. For example, it will likely fail if you already have a Django project deployed on Fly.io. `django-simple-deploy` should only be used on test projects at this point.
+Support for Fly.io is in a preliminary phase. `django-simple-deploy` should only be used on test projects at this point.
 
 Deployment to Fly.io can be fully automated, but the configuration-only approach is recommended. This allows you to review the changes that are made to your project before committing them and making the initial push. The fully automated approach configures your project, commits these changes, and pushes the project to Fly.io's servers.
 
@@ -17,12 +17,12 @@ Deployment to Fly.io can be fully automated, but the configuration-only approach
 Deployment to Fly.io requires three things:
 
 - You must be using Git to track your project.
-- You need to have a `requirements.txt` file at the root of your project.
+- You need to be tracking your dependencies with a `requirements.txt` file, or be using Poetry or Pipenv.
 - The [Fly.io CLI](https://fly.io/docs/hands-on/install-flyctl/) must be installed on your system.
 
 ## Configuration-only deployment
 
-First, install `django-simple-deploy`, and add `simple_deploy` to `INSTALLED_APPS` in *settings.py*:
+First, install `django-simple-deploy` and add `simple_deploy` to `INSTALLED_APPS` in *settings.py*:
 
 ```sh
 $ pip install django-simple-deploy
@@ -33,14 +33,14 @@ $ git commit -am "Added simple_deploy to INSTALLED_APPS."
 Now create a new Fly.io app using the CLI, and run `simple_deploy` to configure your app:
 
 !!! note
-    The `fly` and `flyctl` commands are used on the Fly.io docs interchangeably, we will be using `fly` here.
+    The `fly` and `flyctl` commands are used on the Fly.io docs interchangeably. They are standardizing on `fly`, so that's what we'll be using here.
 
 ```sh
 $ fly apps create --generate-name
 $ python manage.py simple_deploy --platform fly_io
 ```
 
-`simple_deploy` will create a database and link it to the app you just created. It will then configure your project for deployment. At this point, you should review the changes that were made to your project. Running `git status` will show you which files were modified, and which files were created for a successful deployment.
+`simple_deploy` will ask you if it's found the correct app to deploy to. It will then create a database and link it to the app you just created. After that, it will configure your project for deployment. At this point, you should review the changes that were made to your project. Running `git status` will show you which files were modified, and which files were created for a successful deployment.
 
 If you want to continue with the deployment process, commit these changes and run the `deploy` command. When deployment is complete, use the `open` command to see the deployed version of your project:
 
@@ -86,6 +86,6 @@ $ fly ssh console
 
 ## Troubleshooting
 
-If deployment does not work, please feel free to open an [issue](https://github.com/ehmatthes/django-simple-deploy/issues). Please share the OS you're  using locally, and the specific error message or unexpected behavior you saw. If the project you're deploying is hosted in a public repository, please share that as well.
+If deployment doesn't work, feel free to open an [issue](https://github.com/ehmatthes/django-simple-deploy/issues). Please share the OS you're  using locally, and the specific error message or unexpected behavior you saw. If the project you're deploying is hosted in a public repository, please share that as well.
 
 Please remember that `django-simple-deploy` is in a preliminary state. That said, I'd love to know the specific issues people are running into so we can reach a 1.0 state in a reasonable time frame.

--- a/docs/quick_starts/quick_start_flyio.md
+++ b/docs/quick_starts/quick_start_flyio.md
@@ -42,7 +42,7 @@ $ python manage.py simple_deploy --platform fly_io
 
 `simple_deploy` will ask you if it's found the correct app to deploy to. It will then create a database and link it to the app you just created. After that, it will configure your project for deployment. At this point, you should review the changes that were made to your project. Running `git status` will show you which files were modified, and which files were created for a successful deployment.
 
-If you want to continue with the deployment process, commit these changes and run the `deploy` command. When deployment is complete, use the `open` command to see the deployed version of your project:
+If you want to continue with the deployment process, commit these changes and run the `deploy` command; the initial migration is done automatically. When deployment is complete, use the `open` command to see the deployed version of your project:
 
 ```sh
 $ git add .

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -361,7 +361,6 @@ class PlatformDeployer:
             self._validate_cli()
             
             self.deployed_project_name = self._get_deployed_project_name()
-            # sys.exit("***** Stopping for diagnostic work. *****")
 
             # If using automate_all, we need to create the app before creating
             #   the db. But if there's already an app with no deployment, we can 
@@ -447,7 +446,7 @@ class PlatformDeployer:
             # If only one project name, confirm that it's the correct project.
             project_name = project_names[0]
             msg = f"\n*** Found one app on Fly.io: {project_name} ***"
-            print(msg)
+            self.sd.write_output(msg)
             msg = "Is this the app you want to deploy to?"
             if self.sd.get_confirmation(msg):
                 self.app_name = project_name
@@ -463,7 +462,9 @@ class PlatformDeployer:
                     msg += f"\n  {index}: {name}"
                 msg += "\n\nYou can cancel this configuration work by entering q."
                 msg += "\nWhich app would you like to use? "
+                self.sd.log_info(msg)
                 selection = input(msg)
+                self.sd.log_info(selection)
 
                 if selection.lower() in ['q', 'quit']:
                     raise SimpleDeployCommandError(self.sd, flyio_msgs.no_project_name)

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -400,9 +400,8 @@ class PlatformDeployer:
 
     def _get_deployed_project_name(self):
         """Get the Fly.io project name.
-        Parse the output of `fly apps list`, and look for an app name
-          that doesn't have a value set for LATEST DEPLOY. This indicates
-          an app that has just been created, and has not yet been deployed.
+        Parse the output of `fly apps list`, and look for apps that have not
+          been deployed yet.
 
         Also, sets self.app_name, so the name can be used here as well.
 

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -689,11 +689,16 @@ class PlatformDeployer:
         self.sd.log_info(cmd)
         self.sd.log_info(output_str)
 
+        if "No postgres clusters found" in output_str:
+            return False
+
+        # There are some Postgres dbs. Get their names.
         pg_names = [
             pg_dict["Name"]
             for pg_dict in json.loads(output_str)
         ]
 
+        # See if any of these names match this app.
         usable_pg_name = self.app_name + "-db"
         if usable_pg_name in pg_names:
             msg = f"  Postgres db found: {usable_pg_name}"

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -389,7 +389,7 @@ class PlatformDeployer:
     # --- Helper methods for methods called from simple_deploy.py ---
 
     def _validate_cli(self):
-        """Make sure the Platform.sh CLI is installed."""
+        """Make sure the Fly.io CLI is installed."""
         cmd = 'fly version'
         output_obj = self.sd.execute_subp_run(cmd)
         self.sd.log_info(cmd)

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -612,16 +612,9 @@ class PlatformDeployer:
                     return
                 else:
                     # Permission to use this db denied.
-                    # Should we create a new db, or exit?
-                    msg = "Would you like to have a new database provisioned?"
-                    create_new_db = self.sd.get_confirmation(msg)
-                    if create_new_db:
-                        # Continue with creating a db.
-                        # This block does nothing, but I want to make this branch explicit.
-                        #   This block can be removed with some refactoring.
-                        pass
-                    else:
-                        raise SimpleDeployCommandError(self.sd, flyio_msgs.cancel_no_db)
+                    # Can't simply create a new db, because the name we'd use
+                    #   is already taken.
+                    raise SimpleDeployCommandError(self.sd, flyio_msgs.cancel_no_db)
             else:
                 # Existing db is not attached; get permission to attach this db.
                 msg = flyio_msgs.use_unattached_db(db_name, self.db_users)
@@ -638,16 +631,9 @@ class PlatformDeployer:
                     return
                 else:
                     # Permission to use this db denied.
-                    # Should we create a new db, or exit?
-                    msg = "Would you like to have a new database provisioned?"
-                    create_new_db = self.sd.get_confirmation(msg)
-                    if create_new_db:
-                        # Continue with creating a db.
-                        # This block does nothing, but I want to make this branch explicit.
-                        #   This block can be removed with some refactoring.
-                        pass
-                    else:
-                        raise SimpleDeployCommandError(self.sd, flyio_msgs.cancel_no_db)
+                    # Can't simply create a new db, because the name we'd use
+                    #   is already taken.
+                    raise SimpleDeployCommandError(self.sd, flyio_msgs.cancel_no_db)
 
         # No usable db found, create a new db.
         msg = f"  Create a new Postgres database..."

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -625,6 +625,7 @@ class PlatformDeployer:
             else:
                 # Existing db is not attached; get permission to attach this db.
                 msg = flyio_msgs.use_unattached_db(db_name, self.db_users)
+                print("msg:", msg)
                 self.sd.write_output(msg)
 
                 msg = f"Okay to use {db_name} and proceed?"
@@ -756,7 +757,7 @@ class PlatformDeployer:
             tab_index = line.find("\t")
             user = line[:tab_index].strip()
             self.db_users.append(user)
-        self.db_users.append("dummy-user")
+
         self.sd.log_info(f"DB users: {self.db_users}")
 
         default_users = {'flypgadmin', 'postgres', 'repmgr'}

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -621,11 +621,10 @@ class PlatformDeployer:
                         #   This block can be removed with some refactoring.
                         pass
                     else:
-                        raise SimpleDeployCommandError(flyio_msgs.cancel_no_db)
+                        raise SimpleDeployCommandError(self.sd, flyio_msgs.cancel_no_db)
             else:
                 # Existing db is not attached; get permission to attach this db.
                 msg = flyio_msgs.use_unattached_db(db_name, self.db_users)
-                print("msg:", msg)
                 self.sd.write_output(msg)
 
                 msg = f"Okay to use {db_name} and proceed?"
@@ -648,11 +647,7 @@ class PlatformDeployer:
                         #   This block can be removed with some refactoring.
                         pass
                     else:
-                        raise SimpleDeployCommandError(flyio_msgs.cancel_no_db)
-
-            sys.exit()
-
-            return
+                        raise SimpleDeployCommandError(self.sd, flyio_msgs.cancel_no_db)
 
         # No usable db found, create a new db.
         msg = f"  Create a new Postgres database..."

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -434,23 +434,9 @@ class PlatformDeployer:
             if not app_dict["Deployed"]
         ]
 
-
-        deployeds = [
-            app_dict["Deployed"]
-            for app_dict in output_json
-        ]
-        print("Deployeds:", deployeds)
-
-
-
-        print("Candidate apps:", candidate_apps)
-
-
         # Get all names that might be the app we want to deploy to.
         project_names = [apps_dict["Name"] for apps_dict in candidate_apps]
         project_names = [name for name in project_names if 'builder' not in name]
-        print("project names:", project_names)
-        sys.exit()
 
         # We need to respond according to how many possible names were found.
         if len(project_names) == 0:

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -708,8 +708,9 @@ class PlatformDeployer:
         """Check if the db that was found is attached to this app.
 
         Database is considered attached to this app it has a user with the same
-          name as the app. This is the default behavior if you create a new app,
-          then a new db, then attach the db to that app.
+          name as the app, using underscores instead of hyphens.
+        This is the default behavior if you create a new app, then a new db,
+          then attach the db to that app.
 
         Returns:
         - True if db attached to this app.
@@ -742,11 +743,12 @@ class PlatformDeployer:
         self.sd.log_info(f"DB users: {self.db_users}")
 
         default_users = {'flypgadmin', 'postgres', 'repmgr'}
+        app_user = self.app_name.replace('-', '_')
         if set(self.db_users) == default_users:
             # This db only has default users set when a fresh db is made.
             #   Assume it's unattached.
             return False
-        elif (self.app_name in self.db_users) and (len(self.db_users) == 4):
+        elif (app_user in self.db_users) and (len(self.db_users) == 4):
             # The current remote app has been attached to this db.
             #   Will still need confirmation we can use this db.
             return True

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -125,6 +125,22 @@ def confirm_create_db(db_cmd):
     return msg
 
 
+def cant_use_db(db_name, users):
+    """Can't use the db that was found, because it has multiple users."""
+    msg = dedent(f"""
+        We found a database whose name matches the app name: {db_name}
+          This database has the following users:
+          {users}
+        This is more than the default set of users that a freshly-created db
+          will have. It also has a user that doesn't match the name of the app.
+        This situation is unexpected; if you think we should handle this situation, 
+          please open an issue.
+          - https://github.com/ehmatthes/django-simple-deploy/issues
+    """)
+
+    return msg
+
+
 def success_msg(log_output=''):
     """Success message, for configuration-only run."""
 

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -132,14 +132,14 @@ def use_attached_db(db_name, users):
     """
     msg = dedent(f"""
         *** Found a database whose name matches the app name: {db_name} ***
-           This is the naming convention used by simple_deploy, so this is
+        This is the naming convention used by simple_deploy, so this is
           probably a database that was created for you by a previous
           simple_deploy run.
         This database has the following users:
           {users}
         Three of these are the default users, and the fourth is the name of the 
-          app plus -db. This database appears to have been configured to work
-          with this app.
+          app (with underscores). This database appears to have been configured
+          to work with this app.
     """)
 
     return msg
@@ -150,7 +150,7 @@ def use_unattached_db(db_name, users):
     """
     msg = dedent(f"""
         *** Found a database whose name matches the app name: {db_name} ***
-          This is the naming convention used by simple_deploy, so this is
+        This is the naming convention used by simple_deploy, so this is
           probably a database that was created for you by a previous
           simple_deploy run.
         This database has the following users:

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -76,6 +76,8 @@ rest of the process may work.
 cancel_no_db = """
 A database is required for deployment. You may be able to create a database
   manually, and configure it to work with this app.
+If you think there's a database that simple_deploy should be able to use,
+  please open an issue: https://github.com/ehmatthes/django-simple-deploy/issues
 """
 
 

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -44,7 +44,7 @@ After installing the CLI, you can run simple_deploy again.
 """
 
 no_project_name = """
-A Fly.io app name could not be found.
+A Fly.io app to deploy to could not be found.
 
 The simple_deploy command expects that you've already created an app on Fly.io
 to push to.

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -44,7 +44,7 @@ After installing the CLI, you can run simple_deploy again.
 """
 
 no_project_name = """
-A Fly.io app to deploy to could not be found.
+A suitable Fly.io app to deploy against could not be found.
 
 The simple_deploy command expects that you've already created an app on Fly.io
 to push to.
@@ -54,6 +54,9 @@ If you haven't done so, run the following command to create a new Fly.io app:
     $ fly apps create --generate-name
 
 Then run simple_deploy again.
+
+Note: Apps that have already been deployed to are ignored, because we don't want
+  to affect existing projects.
 """
 
 create_app_failed = """

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -140,6 +140,8 @@ def use_attached_db(db_name, users):
           with this app.
     """)
 
+    return msg
+
 
 def use_unattached_db(db_name, users):
     """Found the db unattached, with only default users.
@@ -154,6 +156,8 @@ def use_unattached_db(db_name, users):
         These are the default users for a Fly.io Postgres database. This database
           does not appear to have been used yet.
     """)
+
+    return msg
 
 
 def cant_use_db(db_name, users):

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -75,7 +75,7 @@ rest of the process may work.
 
 cancel_no_db = """
 A database is required for deployment. You may be able to create a database
-manually, and configure it to work with this app.
+  manually, and configure it to work with this app.
 """
 
 
@@ -129,7 +129,7 @@ def use_attached_db(db_name, users):
     """Found the db attached, with only default users and app_name-db user.
     """
     msg = dedent(f"""
-        Found a database whose name matches the app name: {db_name}
+        *** Found a database whose name matches the app name: {db_name} ***
            This is the naming convention used by simple_deploy, so this is
           probably a database that was created for you by a previous
           simple_deploy run.
@@ -147,7 +147,7 @@ def use_unattached_db(db_name, users):
     """Found the db unattached, with only default users.
     """
     msg = dedent(f"""
-        Found a database whose name matches the app name: {db_name}
+        *** Found a database whose name matches the app name: {db_name} ***
           This is the naming convention used by simple_deploy, so this is
           probably a database that was created for you by a previous
           simple_deploy run.

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -8,15 +8,13 @@ from django.conf import settings
 
 
 confirm_preliminary = """
-***** Deployments to Fly.io are experimental at this point ***
+***** Support for Fly.io is in the preliminary phase ***
 
-- Support for deploying to Fly.io is in an exploratory phase at this point.
+- Support for deploying to Fly.io is in the preliminary phase at this point.
 - You should only be using this project to deploy to Fly.io at this point if
   you are interested in helping to develop or test the simple_deploy project.
 - You should look at the deploy_flyio.py script before running this command,
   so you know what kinds of changes will be made to your project.
-- This command will likely fail if you run it more than once.
-- This command may not work if you already have a project deployed to Fly.io.
 - You should understand the Fly.io console, and be comfortable deleting resources
   that are created during this deployment.
 - You may want to cancel this run and deploy to a different platform.
@@ -25,6 +23,7 @@ confirm_preliminary = """
 confirm_automate_all = """
 The --automate-all flag means simple_deploy will:
 - Run `fly apps create` for you, to create an empty Fly.io project.
+- Run `fly postgres create`, to create a new database for your project.
 - Configure your project for deployment on Fly.io.
 - Commit all changes to your project that are necessary for deployment.
 - Push these changes to Fly.io.
@@ -32,14 +31,13 @@ The --automate-all flag means simple_deploy will:
 """
 
 cancel_flyio = """
-Okay, cancelling Fly.io deployment.
+Okay, cancelling Fly.io configuration and deployment.
 """
 
-# DEV: Update URL
 # DEV: This could be moved to deploy_messages, with an arg for platform and URL.
 cli_not_installed = """
 In order to deploy to Fly.io, you need to install the Fly.io CLI.
-  See here: fly_io_url
+  See here: https://fly.io/docs/flyctl/
 After installing the CLI, you can run simple_deploy again.
 """
 
@@ -55,8 +53,8 @@ If you haven't done so, run the following command to create a new Fly.io app:
 
 Then run simple_deploy again.
 
-Note: Apps that have already been deployed to are ignored, because we don't want
-  to affect existing projects.
+Note: Apps that have already been deployed to are ignored, to ensure that existing
+  projects are not impacted by this deployment.
 """
 
 create_app_failed = """
@@ -69,8 +67,8 @@ error messages to troubleshoot app creation:
 
     $ fly apps create --generate-name
 
-If you can get this command to work, you can run simple_deploy again and the 
-rest of the process may work.
+If you can get this command to work, you can run simple_deploy again (without the
+  --automate-all flag), and the rest of the process may work.
 """
 
 cancel_no_db = """
@@ -178,7 +176,11 @@ def cant_use_db(db_name, users):
 
 
 def success_msg(log_output=''):
-    """Success message, for configuration-only run."""
+    """Success message, for configuration-only run.
+
+    Note: This is immensely helpful; I use it just about every time I do a
+      manual test run.
+    """
 
     msg = dedent(f"""
         --- Your project is now configured for deployment on Fly.io ---
@@ -195,7 +197,7 @@ def success_msg(log_output=''):
         - As you develop your project further:
             - Make local changes
             - Commit your local changes
-            - Run `fly deploy`
+            - Run `fly deploy` again to push your changes.
     """)
 
     if log_output:
@@ -213,7 +215,10 @@ def success_msg_automate_all(deployed_url):
 
         --- Your project should now be deployed on Fly.io ---
 
-        It should have opened up in a new browser tab.
+        It should have opened up in a new browser tab. If you see a
+          "server not available" message, wait a minute or two and
+          refresh the tab. It sometimes takes a few minutes for the
+          server to be ready.
         - You can also visit your project at {deployed_url}
 
         If you make further changes and want to push them to Fly.io,

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -104,7 +104,7 @@ def confirm_use_org_name(org_name):
     """Confirm use of this org name to create a new project."""
 
     msg = dedent(f"""
-        --- The Platform.sh CLI requires an organization name when creating a new project. ---
+        --- The Fly.io CLI requires an organization name when creating a new project. ---
         When using --automate-all, a project will be created on your behalf. The following
         organization name was found: {org_name}
 

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -125,17 +125,47 @@ def confirm_create_db(db_cmd):
     return msg
 
 
+def use_attached_db(db_name, users):
+    """Found the db attached, with only default users and app_name-db user.
+    """
+    msg = dedent(f"""
+        Found a database whose name matches the app name: {db_name}
+           This is the naming convention used by simple_deploy, so this is
+          probably a database that was created for you by a previous
+          simple_deploy run.
+        This database has the following users:
+          {users}
+        Three of these are the default users, and the fourth is the name of the 
+          app plus -db. This database appears to have been configured to work
+          with this app.
+    """)
+
+
+def use_unattached_db(db_name, users):
+    """Found the db unattached, with only default users.
+    """
+    msg = dedent(f"""
+        Found a database whose name matches the app name: {db_name}
+          This is the naming convention used by simple_deploy, so this is
+          probably a database that was created for you by a previous
+          simple_deploy run.
+        This database has the following users:
+          {users}
+        These are the default users for a Fly.io Postgres database. This database
+          does not appear to have been used yet.
+    """)
+
+
 def cant_use_db(db_name, users):
     """Can't use the db that was found, because it has multiple users."""
     msg = dedent(f"""
-        We found a database whose name matches the app name: {db_name}
-          This database has the following users:
+        Found a database whose name matches the app name: {db_name}
+        This database has the following users:
           {users}
         This is more than the default set of users that a freshly-created db
           will have. It also has a user that doesn't match the name of the app.
-        This situation is unexpected; if you think we should handle this situation, 
-          please open an issue.
-          - https://github.com/ehmatthes/django-simple-deploy/issues
+        This situation is unexpected; if you think this situation should be handled, 
+          please open an issue: https://github.com/ehmatthes/django-simple-deploy/issues
     """)
 
     return msg

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -468,10 +468,7 @@ class Command(BaseCommand):
             # The only addition was 'simple_deploy', we can move on.
             return True
 
-
         # There was a change, but it wasn't just 'simple_deploy'.
-        print('here')
-        print(output_str)
         # We can proceed if simple_deploy_logs/ was added to .gitignore.
         if all([
                 "diff --git a/.gitignore b/.gitignore" in output_str,

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -926,13 +926,18 @@ class Command(BaseCommand):
             self._write_pipfile_pkg(package_name, version)
 
 
-    def get_confirmation(self, skip_logging=False):
+    def get_confirmation(self, msg="", skip_logging=False):
         """Get confirmation for an action.
         This method assumes an appropriate message has already been displayed
           about what is to be done.
+        You can pass a different message for the prompt; it should be phrased
+          to elicit a yes/no response. Don't include the yes/no part.
         This method shows a yes|no prompt, and returns True or False.
         """
-        prompt = "\nAre you sure you want to do this? (yes|no) "
+        if not msg:
+            prompt = "\nAre you sure you want to do this? (yes|no) "
+        else:
+            prompt = f"\n{msg} (yes|no) "
         confirmed = ''
 
         # If doing integration testing, always return True.

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -467,10 +467,22 @@ class Command(BaseCommand):
         if m:
             # The only addition was 'simple_deploy', we can move on.
             return True
-        else:
-            # There was a change, but it wasn't just 'simple_deploy'.
-            # We should bail and have user look at their status.
-            return False
+
+
+        # There was a change, but it wasn't just 'simple_deploy'.
+        print('here')
+        print(output_str)
+        # We can proceed if simple_deploy_logs/ was added to .gitignore.
+        if all([
+                "diff --git a/.gitignore b/.gitignore" in output_str,
+                "+# Ignore logs from simple_deploy." in output_str,
+                "+simple_deploy_logs/" in output_str
+                ]):
+            return True
+
+        # Couldn't identify an acceptable reason for an unclean status.
+        # We should bail and have user look at their status.
+        return False
 
 
     def _get_dep_man_approach(self):


### PR DESCRIPTION
Deployments to Fly.io would fail previously if you already had a project deployed to Fly.io. If you tried to deploy a second project, it would use an existing db rather than creating a new one.

This PR fixes that. It shows a list of your undeployed Fly apps, and asks you to confirm that simple_deploy has found the right one, or choose the one that should be used if more than one underplayed apps exist.