### PR TITLE
Add requests to installed requirements.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,4 @@ python_requires = >=3.8
 install_requires =
     Django >=  3.0
     toml >= 0.10.2
+    requests >= 2.28.0


### PR DESCRIPTION
Required since 7d1d405385d266861eb284eed2f72b4da87d35e4.
```
$ python manage.py simple_deploy --platform fly_io
...
  File ".venv/lib/python3.10/site-packages/simple_deploy/management/commands/fly_io/deploy.py", line 15, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```