### PR TITLE
Update Python classifiers to include 3.11 and 3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Internet :: WWW/HTTP
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
 


### PR DESCRIPTION
3.11 was released in 2022 and 3.12 in 2023. I assume this project will work on both of them, though I have only briefly tested 3.12 locally.