### PR TITLE
Support pushing multiple projects to Platform.sh.

### DIFF
--- a/docs/quick_starts/quick_start_platformsh.md
+++ b/docs/quick_starts/quick_start_platformsh.md
@@ -8,7 +8,7 @@ hide:
 
 ## Overview
 
-Support for Platform.sh is in a preliminary phase. For example, it won't work if you already have a project deployed to Platform.sh, or if you have more than one org.
+Support for Platform.sh is in a preliminary phase. For example, it won't work if you have more than one Platform.sh org.
 
 Deployment to Platform.sh can be fully automated, but the configuration-only approach is recommended. This allows you to review the changes that are made to your project before committing them and making the initial push. The fully automated approach configures your project, commits these changes, and pushes the project to Platform.sh' servers.
 

--- a/sample_project/blog_project/test_deployed_app_functionality.py
+++ b/sample_project/blog_project/test_deployed_app_functionality.py
@@ -335,7 +335,6 @@ headers = {
 logout_url = f"{app_url}users/logout/"
 r = s.post(logout_url, data=post_data, headers=headers)
 
-print(r.status_code)
 assert r.status_code == 200
 assert "Logged out" in r.text
 assert "You have been logged out. Thank you for visiting!" in r.text

--- a/simple_deploy/management/commands/platform_sh/deploy_messages.py
+++ b/simple_deploy/management/commands/platform_sh/deploy_messages.py
@@ -10,7 +10,6 @@ from django.conf import settings
 confirm_preliminary = """
 ***** Deployment to platform.sh is under active development at this point ***
 
-- If you already have a project deployed on Platform.sh, configuration will fail.
 - If you have more than one org on Platform.sh, configuration will fail.
 """
 


### PR DESCRIPTION
This already works, because creating a Platform.sh project from within a project repo makes a connection to that specific project. Works for both configuration-only and automate-all runs. See #307.