### PR TITLE
Support multiple orgs on Platform.sh.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 #### External changes
 
-- Removed warnings about not supporting multiple projects on Platform.sh.
+- Platform.sh now works for users with multiple orgs, and multiple projects already deployed.
+- Removed warnings about preliminary status of Fly.io and Platform.sh.
 
 #### Internal changes
 

--- a/docs/contributing/parking_lot.md
+++ b/docs/contributing/parking_lot.md
@@ -65,6 +65,7 @@ Platform.sh
 ---
 
 - Update runtime to Python 3.12.
+- The method `_validate_platform()` makes sure the user is authenticated through the CLI. I believe we can remove some checks for authentication in subsequent CLI calls, as in `_get_org_name()`.
 
 
 Heroku

--- a/docs/quick_starts/quick_start_flyio.md
+++ b/docs/quick_starts/quick_start_flyio.md
@@ -8,8 +8,6 @@ hide:
 
 ## Overview
 
-Support for Fly.io is in a preliminary phase. `django-simple-deploy` should only be used on test projects at this point.
-
 Deployment to Fly.io can be fully automated, but the configuration-only approach is recommended. This allows you to review the changes that are made to your project before committing them and making the initial push. The fully automated approach configures your project, commits these changes, and pushes the project to Fly.io's servers.
 
 ## Prerequisites

--- a/docs/quick_starts/quick_start_platformsh.md
+++ b/docs/quick_starts/quick_start_platformsh.md
@@ -8,8 +8,6 @@ hide:
 
 ## Overview
 
-Support for Platform.sh is in a preliminary phase. For example, it won't work if you have more than one Platform.sh org.
-
 Deployment to Platform.sh can be fully automated, but the configuration-only approach is recommended. This allows you to review the changes that are made to your project before committing them and making the initial push. The fully automated approach configures your project, commits these changes, and pushes the project to Platform.sh' servers.
 
 ## Prerequisites

--- a/docs/roadmap/reaching_one_point_o.md
+++ b/docs/roadmap/reaching_one_point_o.md
@@ -69,7 +69,7 @@ Support for a new platform starts out as a proof-of-concept, showing that deploy
 
 | Fly.io | Platform.sh | Heroku |
 | :--------------------------: | :----: | :----: |
-| :fontawesome-regular-square-check: | :fontawesome-regular-square-check: | :fontawesome-regular-square-check: |
+| :fontawesome-solid-square-check: | :fontawesome-solid-square-check: | :fontawesome-solid-square-check: |
 
 ## Other notes
 

--- a/simple_deploy/management/commands/fly_io/deploy.py
+++ b/simple_deploy/management/commands/fly_io/deploy.py
@@ -42,7 +42,6 @@ class PlatformDeployer:
         """Coordinate the overall configuration and deployment."""
         self.sd.write_output("\nConfiguring project for deployment to Fly.io...")
 
-        self._confirm_preliminary()
         self._validate_platform()
 
         self._prep_automate_all()
@@ -57,22 +56,6 @@ class PlatformDeployer:
         self._show_success_message()
 
     # --- Helper methods for deploy() ---
-
-    def _confirm_preliminary(self):
-        """Confirm acknwledgement of preliminary (pre-1.0) state of project."""
-        self.sd.write_output(self.messages.confirm_preliminary)
-
-        # Unit test check is here, so message is logged.
-        if self.sd.unit_testing:
-            return
-
-        if self.sd.get_confirmation():
-            self.sd.write_output("  Continuing with Fly.io deployment...")
-        else:
-            # Quit and invite the user to try another platform. We are happily exiting
-            # the script; there's no need to raise an error.
-            self.sd.write_output(self.messages.cancel_flyio)
-            sys.exit()
 
     def _validate_platform(self):
         """Make sure the local environment and project supports deployment to Fly.io.

--- a/simple_deploy/management/commands/fly_io/deploy_messages.py
+++ b/simple_deploy/management/commands/fly_io/deploy_messages.py
@@ -7,19 +7,6 @@ from textwrap import dedent
 from django.conf import settings
 
 
-confirm_preliminary = """
-***** Support for Fly.io is in the preliminary phase ***
-
-- Support for deploying to Fly.io is in the preliminary phase at this point.
-- You should only be using this project to deploy to Fly.io at this point if
-  you are interested in helping to develop or test the simple_deploy project.
-- You should look at the deploy_flyio.py script before running this command,
-  so you know what kinds of changes will be made to your project.
-- You should understand the Fly.io console, and be comfortable deleting resources
-  that are created during this deployment.
-- You may want to cancel this run and deploy to a different platform.
-"""
-
 confirm_automate_all = """
 The --automate-all flag means simple_deploy will:
 - Run `fly apps create` for you, to create an empty Fly.io project.

--- a/simple_deploy/management/commands/platform_sh/deploy.py
+++ b/simple_deploy/management/commands/platform_sh/deploy.py
@@ -383,15 +383,6 @@ class PlatformDeployer:
         output_str = output_obj.stdout.decode()
         self.sd.log_info(output_str)
 
-        if not output_str:
-            output_str = output_obj.stderr.decode()
-            if "LoginRequiredException" in output_str:
-                raise SimpleDeployCommandError(self.sd, self.messages.login_required)
-            else:
-                error_msg = self.messages.unknown_error
-                error_msg += self.messages.cli_not_installed
-                raise SimpleDeployCommandError(self.sd, error_msg)
-
         org_name = plsh_utils.get_org_name(output_str)
         if not org_name:
             raise SimpleDeployCommandError(self.sd, self.messages.org_not_found)

--- a/simple_deploy/management/commands/platform_sh/deploy.py
+++ b/simple_deploy/management/commands/platform_sh/deploy.py
@@ -389,6 +389,7 @@ class PlatformDeployer:
 
         if len(org_names) == 1:
             # Get permission to use this org.
+            org_name = org_names[0]
             if self._confirm_use_org(org_name):
                 return org_name
 

--- a/simple_deploy/management/commands/platform_sh/deploy.py
+++ b/simple_deploy/management/commands/platform_sh/deploy.py
@@ -41,7 +41,6 @@ class PlatformDeployer:
 
         self.sd.write_output("\nConfiguring project for deployment to Platform.sh...")
 
-        self._confirm_preliminary()
         self._validate_platform()
 
         self._prep_automate_all()
@@ -55,22 +54,6 @@ class PlatformDeployer:
         self._show_success_message()
 
     # --- Helper methods for deploy() ---
-
-    def _confirm_preliminary(self):
-        """Confirm acknwledgement of preliminary (pre-1.0) state of project."""
-        self.sd.write_output(self.messages.confirm_preliminary)
-
-        # Unit test check is here, so message is logged.
-        if self.sd.unit_testing:
-            return
-
-        if self.sd.get_confirmation():
-            self.sd.write_output("  Continuing with platform.sh deployment...")
-        else:
-            # Quit and invite the user to try another platform. We are happily exiting
-            # the script; there's no need to raise an error.
-            self.sd.write_output(self.messages.cancel_plsh)
-            sys.exit()
 
     def _validate_platform(self):
         """Make sure the local environment and project supports deployment to

--- a/simple_deploy/management/commands/platform_sh/deploy_messages.py
+++ b/simple_deploy/management/commands/platform_sh/deploy_messages.py
@@ -7,12 +7,6 @@ from textwrap import dedent
 from django.conf import settings
 
 
-confirm_preliminary = """
-***** Deployment to platform.sh is under active development at this point ***
-
-- If you have more than one org on Platform.sh, configuration will fail.
-"""
-
 confirm_automate_all = """
 The --automate-all flag means simple_deploy will:
 - Run `platform create` for you, to create an empty Platform.sh project.

--- a/simple_deploy/management/commands/platform_sh/deploy_messages.py
+++ b/simple_deploy/management/commands/platform_sh/deploy_messages.py
@@ -75,6 +75,11 @@ You can also do this through the CLI using the `platform organization:create` co
 For help, run `platform help organization:create`.
 """
 
+no_org_available = """
+A Platform.sh org must be used to make a deployment. Please identify or create the org
+you'd like to use, and then try again.
+"""
+
 login_required = """
 You appear to be logged out of the Platform.sh CLI. Please run the 
 command `platform login`, and then run simple_deploy again.
@@ -100,14 +105,14 @@ will do all of the necessary configuration for deployment.
 #   determined as the script runs.
 
 
-def confirm_use_org_name(org_name):
-    """Confirm use of this org name to create a new project."""
+def confirm_use_org(org_name):
+    """Confirm use of this org to create a new project."""
 
     msg = dedent(
         f"""
         --- The Platform.sh CLI requires an organization name when creating a new project. ---
         When using --automate-all, a project will be created on your behalf. The following
-        organization name was found: {org_name}
+        organization was found: {org_name}
 
         This organization will be used to create a new project. If this is not okay,
         enter n to cancel this operation.

--- a/simple_deploy/management/commands/platform_sh/tests/unit_tests/test_plsh_utils.py
+++ b/simple_deploy/management/commands/platform_sh/tests/unit_tests/test_plsh_utils.py
@@ -1,6 +1,7 @@
 """Unit tests for platform.sh utils."""
 
 from pathlib import Path
+from textwrap import dedent
 
 import simple_deploy.management.commands.platform_sh.utils as plsh_utils
 
@@ -21,9 +22,10 @@ def test_get_org_names():
     org_names = plsh_utils.get_org_names(output_str)
     assert org_names == ["username-name"]
 
-    output_str = """Name,Label,Owner email
-org_name,org_label,org_owner@example.com
-org_name_2,org_label_2,org_owner_2@example.com"""
+    output_str = dedent("""\
+        Name,Label,Owner email
+        org_name,org_label,org_owner@example.com
+        org_name_2,org_label_2,org_owner_2@example.com""")
 
     org_names = plsh_utils.get_org_names(output_str)
     assert org_names == ["org_name", "org_name_2"]

--- a/simple_deploy/management/commands/platform_sh/tests/unit_tests/test_plsh_utils.py
+++ b/simple_deploy/management/commands/platform_sh/tests/unit_tests/test_plsh_utils.py
@@ -13,10 +13,17 @@ def test_get_project_name():
     assert project_name == "my_blog_project"
 
 
-def test_get_org_name():
-    """Make sure we get the org name, not label or email."""
+def test_get_org_names():
+    """Make sure we get the org names, not label or email."""
     output_str = (
         "Name,Label,Owner email\nusername-name,username-label,username@example.com"
     )
-    org_name = plsh_utils.get_org_name(output_str)
-    assert org_name == "username-name"
+    org_names = plsh_utils.get_org_names(output_str)
+    assert org_names == ["username-name"]
+
+    output_str = """Name,Label,Owner email
+org_name,org_label,org_owner@example.com
+org_name_2,org_label_2,org_owner_2@example.com"""
+
+    org_names = plsh_utils.get_org_names(output_str)
+    assert org_names == ["org_name", "org_name_2"]

--- a/simple_deploy/management/commands/platform_sh/tests/unit_tests/test_plsh_utils.py
+++ b/simple_deploy/management/commands/platform_sh/tests/unit_tests/test_plsh_utils.py
@@ -16,12 +16,24 @@ def test_get_project_name():
 
 def test_get_org_names():
     """Make sure we get the org names, not label or email."""
-    output_str = (
-        "Name,Label,Owner email\nusername-name,username-label,username@example.com"
-    )
+    # Zero orgs.
+    output_str = dedent("""\
+        No organizations found.
+
+        To create a new organization, run: platform org:create""")
+
+    org_names = plsh_utils.get_org_names(output_str)
+    assert org_names is None
+
+    # One org.
+    output_str = dedent("""\
+        Name,Label,Owner email
+        username-name,username-label,username@example.com""")
+
     org_names = plsh_utils.get_org_names(output_str)
     assert org_names == ["username-name"]
 
+    # Two orgs.
     output_str = dedent("""\
         Name,Label,Owner email
         org_name,org_label,org_owner@example.com

--- a/simple_deploy/management/commands/platform_sh/utils.py
+++ b/simple_deploy/management/commands/platform_sh/utils.py
@@ -41,6 +41,10 @@ def get_org_names(output_str):
 
     Returns:
         list: [str]
+        None: If user has no organizations.
     """
+    if "No organizations found." in output_str:
+        return None
+
     lines = output_str.split("\n")[1:]
     return [line.split(",")[0] for line in lines if line]

--- a/simple_deploy/management/commands/platform_sh/utils.py
+++ b/simple_deploy/management/commands/platform_sh/utils.py
@@ -30,3 +30,17 @@ def get_org_name(output_str):
     org_name = target_line.split(",")[0].strip()
 
     return org_name
+
+def get_org_names(output_str):
+    """Get org names from output of `platform organization:list --yes --format csv`.
+
+    Sample input:
+        Name,Label,Owner email
+        <org-name>,<org-label>,<org-owner@example.com>
+        <org-name-2>,<org-label-2>,<org-owner-2@example.com>
+
+    Returns:
+        list: [str]
+    """
+    lines = output_str.split("\n")[1:]
+    return [line.split(",")[0] for line in lines]

--- a/simple_deploy/management/commands/platform_sh/utils.py
+++ b/simple_deploy/management/commands/platform_sh/utils.py
@@ -43,4 +43,4 @@ def get_org_names(output_str):
         list: [str]
     """
     lines = output_str.split("\n")[1:]
-    return [line.split(",")[0] for line in lines]
+    return [line.split(",")[0] for line in lines if line]

--- a/simple_deploy/management/commands/platform_sh/utils.py
+++ b/simple_deploy/management/commands/platform_sh/utils.py
@@ -17,20 +17,6 @@ def get_project_name(output_str):
     return project_name
 
 
-def get_org_name(output_str):
-    """Get org name from output of `platfrom organizations:list`.
-
-    Run with `--format csv` flag.
-
-    Returns:
-        str: org name
-    """
-    # Assume one org.
-    target_line = output_str.split("\n")[1]
-    org_name = target_line.split(",")[0].strip()
-
-    return org_name
-
 def get_org_names(output_str):
     """Get org names from output of `platform organization:list --yes --format csv`.
 

--- a/tests/integration_tests/platforms/fly_io/test_flyio_config.py
+++ b/tests/integration_tests/platforms/fly_io/test_flyio_config.py
@@ -105,7 +105,6 @@ def test_log_dir(tmp_project):
     # DEV: Update these for more platform-specific log messages.
     # Spot check for opening log messages.
     assert "INFO: Logging run of `manage.py simple_deploy`..." in log_file_text
-    assert "INFO: ***** Support for Fly.io is in the preliminary phase ***" in log_file_text
     assert "INFO: Configuring project for deployment to Fly.io..." in log_file_text
 
     assert "INFO: CLI args:" in log_file_text

--- a/tests/integration_tests/platforms/platform_sh/test_platformsh_config.py
+++ b/tests/integration_tests/platforms/platform_sh/test_platformsh_config.py
@@ -86,7 +86,6 @@ def test_log_dir(tmp_project):
     # DEV: Update these for more platform-specific log messages.
     # Spot check for opening log messages.
     assert "INFO: Logging run of `manage.py simple_deploy`..." in log_file_text
-    assert "INFO: ***** Deployments to platform.sh are experimental at this point ***"
     assert "INFO: Configuring project for deployment to Platform.sh..." in log_file_text
 
     assert "INFO: CLI args:" in log_file_text


### PR DESCRIPTION
Previously, simple_deploy would bail if it found more than one Platform.sh org for the user. Now, if more than one org found, user is asked to select which org to use. Also, removes warnings about preliminary status for Platform.sh and Fly.io.