### PR TITLE
Append to STATICFILES_DIRS if it already exists in settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ For inspiration and motivation, see [Keep a CHANGELOG](https://keepachangelog.co
 
 The goal for the 0.7 series is to support an internal plugin model. There shouldn't be many external changes due to this model, but this is an important enough step towards a 1.0 release that it warrants a bump in the minor version number. The 0.8.0 release should indicate preliminary support for external plugins.
 
+### 0.7.2
+
+#### External changes
+
+- On Fly and Heroku, append to `STATICFILES_DIRS` if it already exists, rather than overwriting the existing setting.
+
 ### 0.7.1
 
 #### External changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-simple-deploy
-version = 0.7.1
+version = 0.7.2
 description = A management command that auto-configures a Django project for deployment.
 long_description = file: README.md
 long_description_content_type=text/markdown

--- a/simple_deploy/management/commands/fly_io/templates/settings.py
+++ b/simple_deploy/management/commands/fly_io/templates/settings.py
@@ -9,7 +9,11 @@ if os.environ.get("ON_FLYIO_SETUP") or os.environ.get("ON_FLYIO"):
     # from https://whitenoise.evans.io/en/stable/#quickstart-for-django-apps
     STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
     STATIC_URL = "/static/"
-    STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
+    try:
+        STATICFILES_DIRS.append(os.path.join(BASE_DIR, "static"))
+    except NameError:
+        STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"),]
+
     i = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
     MIDDLEWARE.insert(i + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
 

--- a/simple_deploy/management/commands/fly_io/tests/integration_tests/reference_files/settings.py
+++ b/simple_deploy/management/commands/fly_io/tests/integration_tests/reference_files/settings.py
@@ -142,7 +142,11 @@ if os.environ.get("ON_FLYIO_SETUP") or os.environ.get("ON_FLYIO"):
     # from https://whitenoise.evans.io/en/stable/#quickstart-for-django-apps
     STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
     STATIC_URL = "/static/"
-    STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
+    try:
+        STATICFILES_DIRS.append(os.path.join(BASE_DIR, "static"))
+    except NameError:
+        STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"),]
+
     i = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
     MIDDLEWARE.insert(i + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
 

--- a/simple_deploy/management/commands/heroku/templates/settings.py
+++ b/simple_deploy/management/commands/heroku/templates/settings.py
@@ -22,7 +22,10 @@ if "ON_HEROKU" in os.environ:
 
     STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
     STATIC_URL = "/static/"
-    STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
+    try:
+        STATICFILES_DIRS.append(os.path.join(BASE_DIR, "static"))
+    except NameError:
+        STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"),]
 
     i = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
     MIDDLEWARE.insert(i + 1, "whitenoise.middleware.WhiteNoiseMiddleware")

--- a/simple_deploy/management/commands/heroku/tests/integration_tests/reference_files/settings.py
+++ b/simple_deploy/management/commands/heroku/tests/integration_tests/reference_files/settings.py
@@ -155,7 +155,10 @@ if "ON_HEROKU" in os.environ:
 
     STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
     STATIC_URL = "/static/"
-    STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
+    try:
+        STATICFILES_DIRS.append(os.path.join(BASE_DIR, "static"))
+    except NameError:
+        STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"),]
 
     i = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
     MIDDLEWARE.insert(i + 1, "whitenoise.middleware.WhiteNoiseMiddleware")


### PR DESCRIPTION
This applies to Fly.io and Heroku.