### PR TITLE
Make sd_config a global in plugin_utils

### DIFF
--- a/simple_deploy/management/commands/fly_io/platform_deployer.py
+++ b/simple_deploy/management/commands/fly_io/platform_deployer.py
@@ -38,8 +38,6 @@ class PlatformDeployer:
 
     def deploy(self, *args, **options):
         """Coordinate the overall configuration and deployment."""
-        # plugin_utils.init(self.sd_config)
-
         plugin_utils.write_output(
             "\nConfiguring project for deployment to Fly.io..."
         )

--- a/simple_deploy/management/commands/fly_io/platform_deployer.py
+++ b/simple_deploy/management/commands/fly_io/platform_deployer.py
@@ -206,7 +206,7 @@ class PlatformDeployer:
         if not self.sd_config.automate_all:
             return
 
-        plugin_utils.commit_changes(self.sd_config)
+        plugin_utils.commit_changes()
 
         # Push project.
         plugin_utils.write_output("  Deploying to Fly.io...")
@@ -300,7 +300,6 @@ class PlatformDeployer:
         """Check to see if a Fly.io settings block already exists."""
         start_line = "# Fly.io settings."
         plugin_utils.check_settings(
-            self.sd_config,
             "Fly.io",
             start_line,
             platform_msgs.flyio_settings_found,
@@ -760,7 +759,7 @@ class PlatformDeployer:
 
         # Show the command that will be run on the user's behalf.
         self.stdout.write(platform_msgs.confirm_create_db(db_cmd))
-        if plugin_utils.get_confirmation(self.sd_config):
+        if plugin_utils.get_confirmation():
             self.stdout.write("  Creating database...")
         else:
             # Quit and invite the user to create a database manually.

--- a/simple_deploy/management/commands/fly_io/platform_deployer.py
+++ b/simple_deploy/management/commands/fly_io/platform_deployer.py
@@ -43,7 +43,7 @@ class PlatformDeployer:
         # plugin_utils.init(self.sd_config)
 
         plugin_utils.write_output(
-            self.sd_config, "\nConfiguring project for deployment to Fly.io..."
+            "\nConfiguring project for deployment to Fly.io..."
         )
 
         self._validate_platform()
@@ -109,7 +109,7 @@ class PlatformDeployer:
         deployment-specific settings.
         """
         msg = "\nSetting ON_FLYIO secret..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
         self._set_secret("ON_FLYIO", "ON_FLYIO=1")
 
     def _set_debug(self):
@@ -117,7 +117,7 @@ class PlatformDeployer:
         deployment-specific settings.
         """
         msg = "Setting DEBUG secret..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
         self._set_secret("DEBUG", "DEBUG=FALSE")
 
     def _add_dockerfile(self):
@@ -191,13 +191,13 @@ class PlatformDeployer:
 
         # Write settings to file.
         plugin_utils.modify_file(
-            self.sd_config, self.sd_config.settings_path, modified_settings_string
+            self.sd_config.settings_path, modified_settings_string
         )
 
     def _add_requirements(self):
         """Add requirements for deploying to Fly.io."""
         requirements = ["gunicorn", "psycopg2-binary", "dj-database-url", "whitenoise"]
-        plugin_utils.add_packages(self.sd_config, requirements)
+        plugin_utils.add_packages(requirements)
 
     def _conclude_automate_all(self):
         """Finish automating the push to Fly.io.
@@ -213,17 +213,17 @@ class PlatformDeployer:
         plugin_utils.commit_changes(self.sd_config)
 
         # Push project.
-        plugin_utils.write_output(self.sd_config, "  Deploying to Fly.io...")
+        plugin_utils.write_output("  Deploying to Fly.io...")
         cmd = "fly deploy"
-        plugin_utils.run_slow_command(self.sd_config, cmd)
+        plugin_utils.run_slow_command(cmd)
 
         # Open project.
         plugin_utils.write_output(
-            self.sd_config, "  Opening deployed app in a new browser tab..."
+            "  Opening deployed app in a new browser tab..."
         )
         cmd = f"fly apps open -a {self.app_name}"
-        output = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output)
+        output = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output)
 
         # Get URL of deployed project.
         url_re = r"(opening )(http.*?)( \.\.\.)"
@@ -241,7 +241,7 @@ class PlatformDeployer:
             msg = platform_msgs.success_msg_automate_all(self.deployed_url)
         else:
             msg = platform_msgs.success_msg(log_output=self.sd_config.log_output)
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
     def _set_secret(self, needle, secret):
         """Set a secret on Fly, if it's not already set.
@@ -253,23 +253,23 @@ class PlatformDeployer:
         # First check if secret has already been set.
         #   Don't log output of `fly secrets list`!
         cmd = f"fly secrets list -a {self.deployed_project_name} --json"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         secrets_json = json.loads(output_obj.stdout.decode())
 
         secrets_keys = [secret["Name"] for secret in secrets_json]
 
         if needle in secrets_keys:
             msg = f"  Found {needle} in existing secrets."
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
             return
 
         cmd = f"fly secrets set -a {self.deployed_project_name} {secret}"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         output_str = output_obj.stdout.decode()
-        plugin_utils.write_output(self.sd_config, output_str)
+        plugin_utils.write_output(output_str)
 
         msg = f"  Set secret: {secret}"
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
     def _build_dockerignore(self):
         """Build the contents of the dockerignore file."""
@@ -317,35 +317,35 @@ class PlatformDeployer:
 
         # This generates a FileNotFoundError on Ubuntu if the CLI is not installed.
         try:
-            output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+            output_obj = plugin_utils.run_quick_command(cmd)
         except FileNotFoundError:
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cli_not_installed
+                platform_msgs.cli_not_installed
             )
 
-        plugin_utils.log_info(self.sd_config, output_obj)
+        plugin_utils.log_info(output_obj)
 
         # DEV: Note which OS this block runs on; I believe it's macOS.
         if output_obj.returncode:
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cli_not_installed
+                platform_msgs.cli_not_installed
             )
 
         # Check that user is authenticated.
         cmd = "fly auth whoami --json"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
 
         error_msg = "Error: No access token available."
         if error_msg in output_obj.stderr.decode():
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cli_logged_out
+                platform_msgs.cli_logged_out
             )
 
         # Show current authenticated fly user.
         whoami_json = json.loads(output_obj.stdout.decode())
         user_email = whoami_json["email"]
         msg = f"  Logged in to Fly.io CLI as: {user_email}"
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
     def _get_deployed_project_name(self):
         """Get the Fly.io project name.
@@ -373,15 +373,15 @@ class PlatformDeployer:
             SimpleDeployCommandError: If deployed project name can't be found.
         """
         msg = "\nLooking for Fly.io app to deploy against..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         # Get info about user's apps on Fly.io.
         cmd = "fly apps list --json"
 
         # Run command, and get json output.
         # CLI has been validated; should not have to deal with stderr.
-        output_str = plugin_utils.run_quick_command(self.sd_config, cmd).stdout.decode()
-        plugin_utils.log_info(self.sd_config, output_str)
+        output_str = plugin_utils.run_quick_command(cmd).stdout.decode()
+        plugin_utils.log_info(output_str)
         output_json = json.loads(output_str)
 
         project_names = self._get_undeployed_projects(output_json)
@@ -389,7 +389,7 @@ class PlatformDeployer:
 
         # Display and return deployed app name.
         msg = f"  Using Fly.io app: {self.app_name}"
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
         return self.app_name
 
     def _get_undeployed_projects(self, output_json):
@@ -416,22 +416,22 @@ class PlatformDeployer:
                 self.app_name = self._create_flyio_app()
             else:
                 raise plugin_utils.SimpleDeployCommandError(
-                    self.sd_config, platform_msgs.no_project_name
+                    platform_msgs.no_project_name
                 )
         elif len(project_names) == 1:
             # Only one app name found. Confirm we can deploy to this app.
             project_name = project_names[0]
             msg = f"\n*** Found one undeployed app on Fly.io: {project_name} ***"
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
 
             prompt = "Is this the app you want to deploy to?"
-            if plugin_utils.get_confirmation(self.sd_config, prompt):
+            if plugin_utils.get_confirmation(prompt):
                 self.app_name = project_name
             elif self.sd_config.automate_all:
                 self.app_name = self._create_flyio_app()
             else:
                 raise plugin_utils.SimpleDeployCommandError(
-                    self.sd_config, platform_msgs.no_project_name
+                    platform_msgs.no_project_name
                 )
         else:
             # More than one undeployed app found. `apps list` doesn't show
@@ -457,14 +457,14 @@ class PlatformDeployer:
             confirmed = False
             while not confirmed:
                 selection = plugin_utils.get_numbered_choice(
-                    self.sd_config, prompt, valid_choices, platform_msgs.no_project_name
+                    prompt, valid_choices, platform_msgs.no_project_name
                 )
                 selected_name = project_names[selection]
 
                 confirm_prompt = f"You have selected {selected_name}."
                 confirm_prompt += " Is that correct?"
                 confirmed = plugin_utils.get_confirmation(
-                    self.sd_config, confirm_prompt
+                    confirm_prompt
                 )
 
             # Create a new app for automated runs, if needed.
@@ -489,12 +489,12 @@ class PlatformDeployer:
             SimpleDeployCommandError: if an app can't be created.
         """
         msg = "  Creating a new app on Fly.io..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         cmd = "fly apps create --generate-name --json"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         output_str = output_obj.stdout.decode()
-        plugin_utils.write_output(self.sd_config, output_str)
+        plugin_utils.write_output(output_str)
 
         # Get app name.
         app_dict = json.loads(output_str)
@@ -502,11 +502,11 @@ class PlatformDeployer:
             self.app_name = app_dict["Name"]
         except KeyError:
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.create_app_failed
+                platform_msgs.create_app_failed
             )
         else:
             msg = f"  Created new app: {self.app_name}"
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
             return self.app_name
 
     def _create_db(self):
@@ -532,7 +532,7 @@ class PlatformDeployer:
             permission to use existing db with matching name.
         """
         msg = "Looking for a Postgres database..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         self.db_name = self.app_name + "-db"
         if self._check_db_exists():
@@ -543,7 +543,7 @@ class PlatformDeployer:
 
         # Create a new db.
         msg = f"  Creating a new Postgres database..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         cmd = f"fly postgres create --name {self.db_name} --region {self.region}"
         cmd += " --initial-cluster-size 1 --vm-size shared-cpu-1x --volume-size 1"
@@ -551,11 +551,11 @@ class PlatformDeployer:
 
         # Create database. Log command, but don't log output because it should contain
         # db credentials. May want to scrub and then log output.
-        plugin_utils.log_info(self.sd_config, cmd)
-        plugin_utils.run_slow_command(self.sd_config, cmd, skip_logging=True)
+        plugin_utils.log_info(cmd)
+        plugin_utils.run_slow_command(cmd, skip_logging=True)
 
         msg = "  Created Postgres database."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         self._attach_db()
 
@@ -588,7 +588,7 @@ class PlatformDeployer:
         """
 
         msg = "Looking for Fly.io region..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         # Get region output.
         url = "https://liveview-counter.fly.dev/"
@@ -600,12 +600,12 @@ class PlatformDeployer:
             region = m.group(1)
 
             msg = f"  Found lowest latency region: {region}"
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
         else:
             region = "sea"
 
             msg = f"  Couldn't find lowest latency region, using 'sea'."
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
 
         return region
 
@@ -618,9 +618,9 @@ class PlatformDeployer:
 
         # First, see if any Postgres clusters exist.
         cmd = "fly postgres list --json"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         output_str = output_obj.stdout.decode()
-        plugin_utils.log_info(self.sd_config, output_str)
+        plugin_utils.log_info(output_str)
 
         if "No postgres clusters found" in output_str:
             return False
@@ -631,11 +631,11 @@ class PlatformDeployer:
         # See if any of these names match this app.
         if self.db_name in pg_names:
             msg = f"  Postgres db found: {self.db_name}"
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
             return True
         else:
             msg = "  No matching Postgres database found."
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
             return False
 
     def _manage_existing_db(self):
@@ -672,13 +672,13 @@ class PlatformDeployer:
         """
         # Get users of this db.
         cmd = f"fly postgres users list -a {self.db_name} --json"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         output_str = output_obj.stdout.decode()
-        plugin_utils.log_info(self.sd_config, output_str)
+        plugin_utils.log_info(output_str)
 
         pg_users_json = json.loads(output_str)
         self.db_users = [user_dict["Username"] for user_dict in pg_users_json]
-        plugin_utils.log_info(self.sd_config, f"DB users: {self.db_users}")
+        plugin_utils.log_info(f"DB users: {self.db_users}")
 
         default_users = {"flypgadmin", "postgres", "repmgr"}
         app_user = self.app_name.replace("-", "_")
@@ -697,7 +697,7 @@ class PlatformDeployer:
             # Note: This path has only been tested once, by manually adding
             # "dummy-user" to the list of db users."
             msg = platform_msgs.cant_use_db(self.db_name, self.db_users)
-            raise plugin_utils.SimpleDeployCommandError(self.sd_config, msg)
+            raise plugin_utils.SimpleDeployCommandError(msg)
 
     def _confirm_use_attached_db(self):
         """Confirm it's okay to use db that's already attached to this app.
@@ -709,14 +709,14 @@ class PlatformDeployer:
             SimpleDeployCommandError: If confirmation denied.
         """
         msg = platform_msgs.use_attached_db(self.db_name, self.db_users)
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         msg = f"Okay to use {self.db_name} and proceed?"
-        if not plugin_utils.get_confirmation(self.sd_config, msg):
+        if not plugin_utils.get_confirmation(msg):
             # Permission to use this db denied. Can't simply create a new db,
             # because the name we'd use is already taken.
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cancel_no_db
+                platform_msgs.cancel_no_db
             )
 
     def _confirm_use_unattached_db(self):
@@ -735,10 +735,10 @@ class PlatformDeployer:
             SimpleDeployCommandError: If confirmation denied.
         """
         msg = platform_msgs.use_unattached_db(self.db_name, self.db_users)
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         msg = f"Okay to use {self.db_name} and proceed?"
-        if plugin_utils.get_confirmation(self.sd_config, msg):
+        if plugin_utils.get_confirmation(msg):
             self._attach_db(self.db_name)
             return
         else:
@@ -746,7 +746,7 @@ class PlatformDeployer:
             # Can't simply create a new db, because the name we'd use is
             # already taken.
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cancel_no_db
+                platform_msgs.cancel_no_db
             )
 
     def _confirm_create_db(self, db_cmd):
@@ -769,26 +769,26 @@ class PlatformDeployer:
         else:
             # Quit and invite the user to create a database manually.
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cancel_no_db
+                platform_msgs.cancel_no_db
             )
 
     def _attach_db(self):
         """Attach the database to the app."""
         msg = "  Attaching database to Fly.io app..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
         cmd = f"fly postgres attach --app {self.deployed_project_name} {self.db_name}"
 
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         output_str = output_obj.stdout.decode()
 
         # Show full output, then scrub for logging.
-        plugin_utils.write_output(self.sd_config, output_str, skip_logging=True)
+        plugin_utils.write_output(output_str, skip_logging=True)
 
         output_scrubbed = [
             l for l in output_str.splitlines() if "DATABASE_URL" not in l
         ]
         output_scrubbed = "\n".join(output_scrubbed)
-        plugin_utils.log_info(self.sd_config, output_scrubbed)
+        plugin_utils.log_info(output_scrubbed)
 
         msg = "  Attached database to app."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)

--- a/simple_deploy/management/commands/fly_io/platform_deployer.py
+++ b/simple_deploy/management/commands/fly_io/platform_deployer.py
@@ -34,10 +34,14 @@ class PlatformDeployer:
         self.stdout = self.sd_config.stdout
         self.templates_path = Path(__file__).parent / "templates"
 
+        plugin_utils.init(self.sd_config)
+
     # --- Public methods ---
 
     def deploy(self, *args, **options):
         """Coordinate the overall configuration and deployment."""
+        # plugin_utils.init(self.sd_config)
+
         plugin_utils.write_output(
             self.sd_config, "\nConfiguring project for deployment to Fly.io..."
         )
@@ -144,7 +148,7 @@ class PlatformDeployer:
 
         # Write file to project.
         path = self.sd_config.project_root / "Dockerfile"
-        plugin_utils.add_file(self.sd_config, path, contents)
+        plugin_utils.add_file(path, contents)
 
     def _add_dockerignore(self):
         """Add a dockerignore file, based on user's local project environmnet.
@@ -152,7 +156,7 @@ class PlatformDeployer:
         """
         path = self.sd_config.project_root / ".dockerignore"
         dockerignore_str = self._build_dockerignore()
-        plugin_utils.add_file(self.sd_config, path, dockerignore_str)
+        plugin_utils.add_file(path, dockerignore_str)
 
     def _add_flytoml(self):
         """Add a minimal fly.toml file."""
@@ -167,7 +171,7 @@ class PlatformDeployer:
 
         # Write file to project.
         path = self.sd_config.project_root / "fly.toml"
-        plugin_utils.add_file(self.sd_config, path, contents)
+        plugin_utils.add_file(path, contents)
 
     def _modify_settings(self):
         """Add platformsh-specific settings."""

--- a/simple_deploy/management/commands/fly_io/platform_deployer.py
+++ b/simple_deploy/management/commands/fly_io/platform_deployer.py
@@ -34,8 +34,6 @@ class PlatformDeployer:
         self.stdout = self.sd_config.stdout
         self.templates_path = Path(__file__).parent / "templates"
 
-        plugin_utils.init(self.sd_config)
-
     # --- Public methods ---
 
     def deploy(self, *args, **options):

--- a/simple_deploy/management/commands/heroku/platform_deployer.py
+++ b/simple_deploy/management/commands/heroku/platform_deployer.py
@@ -341,7 +341,6 @@ class PlatformDeployer:
         """Check to see if a Heroku settings block already exists."""
         start_line = "# Heroku settings."
         plugin_utils.check_settings(
-            self.sd_config,
             "Heroku",
             start_line,
             platform_msgs.heroku_settings_found,

--- a/simple_deploy/management/commands/heroku/platform_deployer.py
+++ b/simple_deploy/management/commands/heroku/platform_deployer.py
@@ -29,8 +29,6 @@ class PlatformDeployer:
         self.stdout = sd_config.stdout
         self.templates_path = Path(__file__).parent / "templates"
 
-        plugin_utils.init(sd_config)
-
     # --- Public methods ---
 
     def deploy(self, *args, **options):

--- a/simple_deploy/management/commands/heroku/platform_deployer.py
+++ b/simple_deploy/management/commands/heroku/platform_deployer.py
@@ -29,11 +29,13 @@ class PlatformDeployer:
         self.stdout = sd_config.stdout
         self.templates_path = Path(__file__).parent / "templates"
 
+        plugin_utils.init(sd_config)
+
     # --- Public methods ---
 
     def deploy(self, *args, **options):
         plugin_utils.write_output(
-            self.sd_config, "\nConfiguring project for deployment to Heroku..."
+            "\nConfiguring project for deployment to Heroku..."
         )
 
         self._validate_platform()
@@ -98,27 +100,27 @@ class PlatformDeployer:
             return
 
         msg = "  Generating a requirements.txt file, because Heroku does not support Poetry directly..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         cmd = "poetry export -f requirements.txt --output requirements.txt --without-hashes"
-        output = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output)
+        output = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output)
 
         msg = "    Wrote requirements.txt file."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         # From this point forward, treat this user the same as anyone who's using a bare
         # requirements.txt file.
         self.sd_config.pkg_manager = "req_txt"
         self.sd_config.req_txt_path = self.sd_config.git_path / "requirements.txt"
-        plugin_utils.log_info(self.sd_config, "    Package manager set to req_txt.")
+        plugin_utils.log_info("    Package manager set to req_txt.")
         plugin_utils.log_info(
-            self.sd_config, f"    req_txt path: {self.sd_config.req_txt_path}"
+            f"    req_txt path: {self.sd_config.req_txt_path}"
         )
 
         # Add simple_deploy, because it wasn't done earlier for poetry.
         # This may be a bug in how poetry is handled by core.
-        plugin_utils.add_package(self.sd_config, "django-simple-deploy")
+        plugin_utils.add_package("django-simple-deploy")
 
     def _prep_automate_all(self):
         """Do intial work for automating entire process.
@@ -135,10 +137,10 @@ class PlatformDeployer:
             return
 
         # Create heroku app.
-        plugin_utils.write_output(self.sd_config, "  Running `heroku create`...")
+        plugin_utils.write_output("  Running `heroku create`...")
         cmd = "heroku create --json"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output_obj)
+        output_obj = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output_obj)
 
         # Get name of app.
         output_json = json.loads(output_obj.stdout.decode())
@@ -175,11 +177,11 @@ class PlatformDeployer:
 
         if db_exists:
             msg = f"  Found a {plan_name} database."
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
             return
 
         msg = f"  Could not find an existing database. Creating one now..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
         self._create_postgres_db()
 
     def _add_requirements(self):
@@ -187,7 +189,7 @@ class PlatformDeployer:
         # psycopg2 2.9 causes "database connection isn't set to UTC" issue.
         #   See: https://github.com/ehmatthes/heroku-buildpack-python/issues/31
         packages = ["gunicorn", "psycopg2", "dj-database-url", "whitenoise"]
-        plugin_utils.add_packages(self.sd_config, packages)
+        plugin_utils.add_packages(packages)
 
     def _set_env_vars(self):
         """Set Heroku-specific environment variables."""
@@ -208,25 +210,25 @@ class PlatformDeployer:
 
         # Write Procfile.
         path = self.sd_config.project_root / "Procfile"
-        plugin_utils.add_file(self.sd_config, path, proc_command)
+        plugin_utils.add_file(path, proc_command)
 
     def _add_static_file_directory(self):
         """Create a folder for static files, if it doesn't already exist."""
         # Make sure directory exists.
         path_static = self.sd_config.project_root / "static"
-        plugin_utils.add_dir(self.sd_config, path_static)
+        plugin_utils.add_dir(path_static)
 
         # If static/ is not empty, we don't need to do anything.
         if any(path_static.iterdir()):
             plugin_utils.write_output(
-                self.sd_config, "    Found non-empty static files directory."
+                "    Found non-empty static files directory."
             )
             return
 
         # static/ is empty; add a placeholder file to the directory.
         path_placeholder = path_static / "placeholder.txt"
         msg = "This is a placeholder file to make sure this folder is pushed to Heroku."
-        plugin_utils.add_file(self.sd_config, path_placeholder, msg)
+        plugin_utils.add_file(path_placeholder, msg)
 
     def _modify_settings(self):
         """Add Heroku-specific settings.
@@ -247,7 +249,7 @@ class PlatformDeployer:
 
         # Write settings to file.
         plugin_utils.modify_file(
-            self.sd_config, self.sd_config.settings_path, modified_settings_string
+            self.sd_config.settings_path, modified_settings_string
         )
 
     def _conclude_automate_all(self):
@@ -259,42 +261,42 @@ class PlatformDeployer:
             self.sd_config,
         )
 
-        plugin_utils.write_output(self.sd_config, "  Pushing to heroku...")
+        plugin_utils.write_output("  Pushing to heroku...")
 
         # Get the current branch name.
         cmd = "git branch --show-current"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output_obj)
+        output_obj = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output_obj)
         self.current_branch = output_obj.stdout.decode().strip()
 
         # Push current local branch to Heroku main branch.
         # DEV: Note that the output of `git push heroku` goes to stderr, not stdout.
         plugin_utils.write_output(
-            self.sd_config, f"    Pushing branch {self.current_branch}..."
+            f"    Pushing branch {self.current_branch}..."
         )
         if self.current_branch in ("main", "master"):
             cmd = f"git push heroku {self.current_branch}"
         else:
             cmd = f"git push heroku {self.current_branch}:main"
-        plugin_utils.run_slow_command(self.sd_config, cmd)
+        plugin_utils.run_slow_command(cmd)
 
         # Run initial set of migrations.
-        plugin_utils.write_output(self.sd_config, "  Migrating deployed app...")
+        plugin_utils.write_output("  Migrating deployed app...")
         if self.sd_config.nested_project:
             cmd = f"heroku run python {self.sd_config.local_project_name}/manage.py migrate"
         else:
             cmd = "heroku run python manage.py migrate"
-        output = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output = plugin_utils.run_quick_command(cmd)
 
-        plugin_utils.write_output(self.sd_config, output)
+        plugin_utils.write_output(output)
 
         # Open Heroku app, so it simply appears in user's browser.
         plugin_utils.write_output(
-            self.sd_config, "  Opening deployed app in a new browser tab..."
+            "  Opening deployed app in a new browser tab..."
         )
         cmd = "heroku open"
-        output = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output)
+        output = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output)
 
     def _summarize_deployment(self):
         """Manage all tasks related to generating and showing the friendly
@@ -331,7 +333,7 @@ class PlatformDeployer:
                 self.sd_config.pkg_manager, self.heroku_app_name
             )
 
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
     # --- Utility methods ---
 
@@ -360,20 +362,20 @@ class PlatformDeployer:
 
         cmd = "heroku --version"
         try:
-            output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+            output_obj = plugin_utils.run_quick_command(cmd)
         except FileNotFoundError:
             # This generates a FileNotFoundError on Linux (Ubuntu) if CLI not installed.
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cli_not_installed
+                platform_msgs.cli_not_installed
             )
 
-        plugin_utils.log_info(self.sd_config, output_obj)
+        plugin_utils.log_info(output_obj)
 
         # The returncode for a successful command is 0, so anything truthy means the
         # command errored out.
         if output_obj.returncode:
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cli_not_installed
+                platform_msgs.cli_not_installed
             )
 
     def _check_cli_authenticated(self):
@@ -389,8 +391,8 @@ class PlatformDeployer:
             return
 
         cmd = "heroku auth:whoami"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.log_info(self.sd_config, output_obj)
+        output_obj = plugin_utils.run_quick_command(cmd)
+        plugin_utils.log_info(output_obj)
 
         output_str = output_obj.stderr.decode()
         # I believe I've seen both of these messages when not logged in.
@@ -398,7 +400,7 @@ class PlatformDeployer:
             "Error: not logged in" in output_str
         ):
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cli_not_authenticated
+                platform_msgs.cli_not_authenticated
             )
 
     def _check_heroku_project_available(self):
@@ -425,18 +427,18 @@ class PlatformDeployer:
             return
 
         plugin_utils.write_output(
-            self.sd_config, "  Looking for Heroku app to push to..."
+            "  Looking for Heroku app to push to..."
         )
         cmd = "heroku apps:info --json"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output_obj)
+        output_obj = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output_obj)
 
         output_str = output_obj.stdout.decode()
 
         # If output_str is emtpy, there is no heroku app.
         if not output_str:
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.no_heroku_app_detected
+                platform_msgs.no_heroku_app_detected
             )
 
         # Parse output for app_name.
@@ -444,7 +446,7 @@ class PlatformDeployer:
         app_dict = self.apps_list["app"]
         self.heroku_app_name = app_dict["name"]
         plugin_utils.write_output(
-            self.sd_config, f"    Found Heroku app: {self.heroku_app_name}"
+            f"    Found Heroku app: {self.heroku_app_name}"
         )
 
     def _create_postgres_db(self):
@@ -453,25 +455,25 @@ class PlatformDeployer:
         Returns:
             None
         """
-        plugin_utils.write_output(self.sd_config, "  Creating Postgres database...")
-        plugin_utils.write_output(self.sd_config, "  (This may take several minutes.)")
+        plugin_utils.write_output("  Creating Postgres database...")
+        plugin_utils.write_output("  (This may take several minutes.)")
         cmd = "heroku addons:create heroku-postgresql:essential-0 --wait"
-        output = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output)
+        output = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output)
 
     def _set_heroku_env_var(self):
         """Set a config var to indicate when we're in the Heroku environment.
         This is mostly used to modify settings for the deployed project.
         """
         plugin_utils.write_output(
-            self.sd_config, "  Setting Heroku environment variable..."
+            "  Setting Heroku environment variable..."
         )
         cmd = "heroku config:set ON_HEROKU=1"
-        output = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output)
-        plugin_utils.write_output(self.sd_config, "    Set ON_HEROKU=1.")
+        output = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output)
+        plugin_utils.write_output("    Set ON_HEROKU=1.")
         plugin_utils.write_output(
-            self.sd_config, "    This is used to define Heroku-specific settings."
+            "    This is used to define Heroku-specific settings."
         )
 
     def _set_debug_env_var(self):
@@ -485,12 +487,12 @@ class PlatformDeployer:
         #    os.environ.get('DEBUG') == 'TRUE'
         # returns the bool value True for 'TRUE', and False for 'FALSE'.
         # Taken from: https://stackoverflow.com/a/56828137/748891
-        plugin_utils.write_output(self.sd_config, "  Setting DEBUG env var...")
+        plugin_utils.write_output("  Setting DEBUG env var...")
         cmd = "heroku config:set DEBUG=FALSE"
-        output = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output)
+        output = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output)
         plugin_utils.write_output(
-            self.sd_config, "    Set DEBUG config variable to FALSE."
+            "    Set DEBUG config variable to FALSE."
         )
 
     def _set_secret_key_env_var(self):
@@ -506,12 +508,12 @@ class PlatformDeployer:
 
         # Set the new key as an env var on Heroku.
         plugin_utils.write_output(
-            self.sd_config, "  Setting new secret key for Heroku..."
+            "  Setting new secret key for Heroku..."
         )
         cmd = f"heroku config:set SECRET_KEY={new_secret_key}"
-        output = plugin_utils.run_quick_command(self.sd_config, cmd, skip_logging=True)
-        plugin_utils.write_output(self.sd_config, output)
-        plugin_utils.write_output(self.sd_config, "    Set SECRET_KEY config variable.")
+        output = plugin_utils.run_quick_command(cmd, skip_logging=True)
+        plugin_utils.write_output(output)
+        plugin_utils.write_output("    Set SECRET_KEY config variable.")
 
     def _generate_summary(self):
         """Generate the friendly summary, which is html for now."""
@@ -522,7 +524,7 @@ class PlatformDeployer:
         # path.write_text(summary_str, encoding="utf-8")
 
         # msg = f"\n  Generated friendly summary: {path}"
-        # plugin_utils.write_output(self.sd_config, msg)
+        # plugin_utils.write_output(msg)
         pass
         # When implementing this, write a plugin utility to write the contents of the
         # friendly summary to file.

--- a/simple_deploy/management/commands/heroku/platform_deployer.py
+++ b/simple_deploy/management/commands/heroku/platform_deployer.py
@@ -255,9 +255,7 @@ class PlatformDeployer:
         if not self.sd_config.automate_all:
             return
 
-        plugin_utils.commit_changes(
-            self.sd_config,
-        )
+        plugin_utils.commit_changes()
 
         plugin_utils.write_output("  Pushing to heroku...")
 

--- a/simple_deploy/management/commands/platform_sh/platform_deployer.py
+++ b/simple_deploy/management/commands/platform_sh/platform_deployer.py
@@ -195,9 +195,7 @@ class PlatformDeployer:
         if not self.sd_config.automate_all:
             return
 
-        plugin_utils.commit_changes(
-            self.sd_config,
-        )
+        plugin_utils.commit_changes()
 
         # Push project.
         plugin_utils.write_output("  Pushing to Platform.sh...")
@@ -252,7 +250,6 @@ class PlatformDeployer:
         """Check to see if a Platform.sh settings block already exists."""
         start_line = "# Platform.sh settings."
         plugin_utils.check_settings(
-            self.sd_config,
             "Platform.sh",
             start_line,
             platform_msgs.plsh_settings_found,

--- a/simple_deploy/management/commands/platform_sh/platform_deployer.py
+++ b/simple_deploy/management/commands/platform_sh/platform_deployer.py
@@ -36,9 +36,8 @@ class PlatformDeployer:
 
     def deploy(self, *args, **options):
         """Coordinate the overall configuration and deployment."""
-
         plugin_utils.write_output(
-            self.sd_config, "\nConfiguring project for deployment to Platform.sh..."
+            "\nConfiguring project for deployment to Platform.sh..."
         )
 
         self._validate_platform()
@@ -74,7 +73,7 @@ class PlatformDeployer:
             # passed to the simple_deploy CLI.
             self.deployed_project_name = self.sd_config.deployed_project_name
             plugin_utils.log_info(
-                self.sd_config, f"Deployed project name: {self.deployed_project_name}"
+                f"Deployed project name: {self.deployed_project_name}"
             )
             return
 
@@ -83,11 +82,11 @@ class PlatformDeployer:
 
         self.deployed_project_name = self._get_platformsh_project_name()
         plugin_utils.log_info(
-            self.sd_config, f"Deployed project name: {self.deployed_project_name}"
+            f"Deployed project name: {self.deployed_project_name}"
         )
 
         self.org_name = self._get_org_name()
-        plugin_utils.log_info(self.sd_config, f"\nOrg name: {self.org_name}")
+        plugin_utils.log_info(f"\nOrg name: {self.org_name}")
 
     def _prep_automate_all(self):
         """Intial work for automating entire process.
@@ -104,9 +103,9 @@ class PlatformDeployer:
         if not self.sd_config.automate_all:
             return
 
-        plugin_utils.write_output(self.sd_config, "  Running `platform create`...")
+        plugin_utils.write_output("  Running `platform create`...")
         plugin_utils.write_output(
-            self.sd_config, "    (Please be patient, this can take a few minutes."
+            "    (Please be patient, this can take a few minutes."
         )
         cmd = f"platform create --title { self.deployed_project_name } --org {self.org_name} --region {self.sd_config.region} --yes"
 
@@ -116,10 +115,10 @@ class PlatformDeployer:
             # is raised.
             # Also, create command outputs project id to stdout if known, all other
             # output goes to stderr.
-            plugin_utils.run_slow_command(self.sd_config, cmd)
+            plugin_utils.run_slow_command(cmd)
         except subprocess.CalledProcessError as e:
             error_msg = platform_msgs.unknown_create_error(e)
-            raise plugin_utils.SimpleDeployCommandError(self.sd_config, error_msg)
+            raise plugin_utils.SimpleDeployCommandError(error_msg)
 
     def _modify_settings(self):
         """Add platformsh-specific settings.
@@ -140,7 +139,7 @@ class PlatformDeployer:
 
         # Write settings to file.
         plugin_utils.modify_file(
-            self.sd_config, self.sd_config.settings_path, modified_settings_string
+            self.sd_config.settings_path, modified_settings_string
         )
 
     def _add_platform_app_yaml(self):
@@ -164,17 +163,17 @@ class PlatformDeployer:
 
         # Write file to project.
         path = self.sd_config.project_root / ".platform.app.yaml"
-        plugin_utils.add_file(self.sd_config, path, contents)
+        plugin_utils.add_file(path, contents)
 
     def _add_requirements(self):
         """Add requirements for Platform.sh."""
         requirements = ["platformshconfig", "gunicorn", "psycopg2"]
-        plugin_utils.add_packages(self.sd_config, requirements)
+        plugin_utils.add_packages(requirements)
 
     def _add_platform_dir(self):
         """Add a .platform directory, if it doesn't already exist."""
         self.platform_dir_path = self.sd_config.project_root / ".platform"
-        plugin_utils.add_dir(self.sd_config, self.platform_dir_path)
+        plugin_utils.add_dir(self.platform_dir_path)
 
     def _add_services_yaml(self):
         """Add the .platform/services.yaml file."""
@@ -183,7 +182,7 @@ class PlatformDeployer:
         contents = plugin_utils.get_template_string(template_path, context=None)
 
         path = self.platform_dir_path / "services.yaml"
-        plugin_utils.add_file(self.sd_config, path, contents)
+        plugin_utils.add_file(path, contents)
 
     def _conclude_automate_all(self):
         """Finish automating the push to Platform.sh.
@@ -201,25 +200,25 @@ class PlatformDeployer:
         )
 
         # Push project.
-        plugin_utils.write_output(self.sd_config, "  Pushing to Platform.sh...")
+        plugin_utils.write_output("  Pushing to Platform.sh...")
 
         # Pause to make sure project that was just created can be used.
         plugin_utils.write_output(
-            self.sd_config, "    Pausing 10s to make sure project is ready to use..."
+            "    Pausing 10s to make sure project is ready to use..."
         )
         time.sleep(10)
 
         # Use run_slow_command(), to stream output as it runs.
         cmd = "platform push --yes"
-        plugin_utils.run_slow_command(self.sd_config, cmd)
+        plugin_utils.run_slow_command(cmd)
 
         # Open project.
         plugin_utils.write_output(
-            self.sd_config, "  Opening deployed app in a new browser tab..."
+            "  Opening deployed app in a new browser tab..."
         )
         cmd = "platform url --yes"
-        output = plugin_utils.run_quick_command(self.sd_config, cmd)
-        plugin_utils.write_output(self.sd_config, output)
+        output = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output)
 
         # Get url of deployed project.
         #   This can be done with an re, but there's one line of output with
@@ -242,10 +241,10 @@ class PlatformDeployer:
 
         if self.sd_config.automate_all:
             msg = platform_msgs.success_msg_automate_all(self.deployed_url)
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
         else:
             msg = platform_msgs.success_msg(self.sd_config.log_output)
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
 
     # --- Helper methods for methods called from simple_deploy.py ---
 
@@ -266,21 +265,21 @@ class PlatformDeployer:
 
         # This generates a FileNotFoundError on Ubuntu if the CLI is not installed.
         try:
-            output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+            output_obj = plugin_utils.run_quick_command(cmd)
         except FileNotFoundError:
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cli_not_installed
+                platform_msgs.cli_not_installed
             )
 
-        plugin_utils.log_info(self.sd_config, output_obj)
+        plugin_utils.log_info(output_obj)
 
         # Check that the user is authenticated.
         cmd = "platform auth:info --no-interaction"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
 
         if "Authentication is required." in output_obj.stderr.decode():
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.cli_logged_out
+                platform_msgs.cli_logged_out
             )
 
     def _get_platformsh_project_name(self):
@@ -309,12 +308,12 @@ class PlatformDeployer:
         # Use --yes flag to avoid interactive prompt hanging in background
         #   if the user is not currently logged in to the CLI.
         cmd = "platform project:info --yes --format csv"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         output_str = output_obj.stdout.decode()
 
         # Log cmd, but don't log the output of `project:info`. It contains identifying
         # information about the user and project, including client_ssh_key.
-        plugin_utils.log_info(self.sd_config, cmd)
+        plugin_utils.log_info(cmd)
 
         # If there's no stdout, the user is probably logged out, hasn't called
         #   create, or doesn't have the CLI installed.
@@ -324,20 +323,20 @@ class PlatformDeployer:
             output_str = output_obj.stderr.decode()
             if "LoginRequiredException" in output_str:
                 raise plugin_utils.SimpleDeployCommandError(
-                    self.sd_config, platform_msgs.login_required
+                    platform_msgs.login_required
                 )
             elif "ProjectNotFoundException" in output_str:
                 raise plugin_utils.SimpleDeployCommandError(
-                    self.sd_config, platform_msgs.no_project_name
+                    platform_msgs.no_project_name
                 )
             elif "RootNotFoundException" in output_str:
                 raise plugin_utils.SimpleDeployCommandError(
-                    self.sd_config, platform_msgs.no_project_name
+                    platform_msgs.no_project_name
                 )
             else:
                 error_msg = platform_msgs.unknown_error
                 error_msg += platform_msgs.cli_not_installed
-                raise plugin_utils.SimpleDeployCommandError(self.sd_config, error_msg)
+                raise plugin_utils.SimpleDeployCommandError(error_msg)
 
         # Pull deployed project name from output.
         lines = output_str.splitlines()
@@ -355,7 +354,7 @@ class PlatformDeployer:
 
         # Couldn't find a project name. Warn user, and tell them about override flag.
         raise plugin_utils.SimpleDeployCommandError(
-            self.sd_config, platform_msgs.no_project_name
+            platform_msgs.no_project_name
         )
 
     def _get_org_name(self):
@@ -376,14 +375,14 @@ class PlatformDeployer:
             return
 
         cmd = "platform organization:list --yes --format csv"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         output_str = output_obj.stdout.decode()
-        plugin_utils.log_info(self.sd_config, output_str)
+        plugin_utils.log_info(output_str)
 
         org_names = plsh_utils.get_org_names(output_str)
         if not org_names:
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, platform_msgs.org_not_found
+                platform_msgs.org_not_found
             )
 
         if len(org_names) == 1:
@@ -404,13 +403,13 @@ class PlatformDeployer:
         confirmed = False
         while not confirmed:
             selection = plugin_utils.get_numbered_choice(
-                self.sd_config, prompt, valid_choices, platform_msgs.no_org_available
+                prompt, valid_choices, platform_msgs.no_org_available
             )
             selected_org = org_names[selection]
 
             confirm_prompt = f"You have selected {selected_org}."
             confirm_prompt += " Is that correct?"
-            confirmed = plugin_utils.get_confirmation(self.sd_config, confirm_prompt)
+            confirmed = plugin_utils.get_confirmation(confirm_prompt)
 
             return selected_org
 
@@ -423,7 +422,7 @@ class PlatformDeployer:
         """
 
         self.stdout.write(platform_msgs.confirm_use_org(org_name))
-        confirmed = plugin_utils.get_confirmation(self.sd_config, skip_logging=True)
+        confirmed = plugin_utils.get_confirmation(skip_logging=True)
 
         if confirmed:
             self.stdout.write("  Okay, continuing with deployment.")
@@ -432,4 +431,4 @@ class PlatformDeployer:
             # Exit, with a message that configuration is still an option.
             msg = platform_msgs.cancel_plsh
             msg += platform_msgs.may_configure
-            raise plugin_utils.SimpleDeployCommandError(self.sd_config, msg)
+            raise plugin_utils.SimpleDeployCommandError(msg)

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -133,6 +133,7 @@ class Command(BaseCommand):
 
         self._confirm_automate_all(pm)
         # sd_config = self._get_sd_config()
+        self.sd_config.validate()
         pm.hook.simple_deploy_deploy(sd_config=self.sd_config)
 
     def _parse_cli_options(self, options):

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
         plugin_utils.init(self.sd_config)
         
         plugin_utils.write_output(
-            self.sd_config, "Configuring project for deployment...", skip_logging=True
+            "Configuring project for deployment...", skip_logging=True
         )
 
         # CLI options need to be parsed before logging starts, in case --no-logging
@@ -181,15 +181,15 @@ class Command(BaseCommand):
         )
 
         plugin_utils.write_output(
-            self.sd_config, "Logging run of `manage.py simple_deploy`..."
+            "Logging run of `manage.py simple_deploy`..."
         )
-        plugin_utils.write_output(self.sd_config, f"Created {verbose_log_path}.")
+        plugin_utils.write_output(f"Created {verbose_log_path}.")
 
     def _log_cli_args(self, options):
         """Log the args used for this call."""
-        plugin_utils.log_info(self.sd_config, f"\nCLI args:")
+        plugin_utils.log_info(f"\nCLI args:")
         for option, value in options.items():
-            plugin_utils.log_info(self.sd_config, f"  {option}: {value}")
+            plugin_utils.log_info(f"  {option}: {value}")
 
     def _create_log_dir(self):
         """Create a directory to hold log files, if not already present.
@@ -215,15 +215,15 @@ class Command(BaseCommand):
         """
         if not self.platform:
             raise plugin_utils.SimpleDeployCommandError(
-                self.sd_config, sd_messages.requires_platform_flag
+                sd_messages.requires_platform_flag
             )
         elif self.platform in ["fly_io", "platform_sh", "heroku"]:
             plugin_utils.write_output(
-                self.sd_config, f"\nDeployment target: {self.platform}"
+                f"\nDeployment target: {self.platform}"
             )
         else:
             error_msg = sd_messages.invalid_platform_msg(self.platform)
-            raise plugin_utils.SimpleDeployCommandError(self.sd_config, error_msg)
+            raise plugin_utils.SimpleDeployCommandError(error_msg)
 
     def _inspect_system(self):
         """Inspect the user's local system for relevant information.
@@ -239,10 +239,10 @@ class Command(BaseCommand):
         if platform.system() == "Windows":
             self.sd_config.on_windows = True
             self.sd_config.use_shell = True
-            plugin_utils.log_info(self.sd_config, "Local platform identified: Windows")
+            plugin_utils.log_info("Local platform identified: Windows")
         elif platform.system() == "Darwin":
             self.sd_config.on_macos = True
-            plugin_utils.log_info(self.sd_config, "Local platform identified: macOS")
+            plugin_utils.log_info("Local platform identified: macOS")
 
     def _inspect_project(self):
         """Inspect the local project.
@@ -267,12 +267,12 @@ class Command(BaseCommand):
         """
         self.sd_config.local_project_name = settings.ROOT_URLCONF.replace(".urls", "")
         plugin_utils.log_info(
-            self.sd_config, f"Local project name: {self.sd_config.local_project_name}"
+            f"Local project name: {self.sd_config.local_project_name}"
         )
 
         self.sd_config.project_root = settings.BASE_DIR
         plugin_utils.log_info(
-            self.sd_config, f"Project root: {self.sd_config.project_root}"
+            f"Project root: {self.sd_config.project_root}"
         )
 
         # Find .git location, and make sure there's a clean status.
@@ -292,7 +292,7 @@ class Command(BaseCommand):
         # Find out which package manager is being used: req_txt, poetry, or pipenv
         self.sd_config.pkg_manager = self._get_dep_man_approach()
         msg = f"Dependency management system: {self.sd_config.pkg_manager}"
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         self.sd_config.requirements = self._get_current_requirements()
 
@@ -320,19 +320,19 @@ class Command(BaseCommand):
         if (self.sd_config.project_root / ".git").exists():
             self.sd_config.git_path = self.sd_config.project_root
             plugin_utils.write_output(
-                self.sd_config, f"Found .git dir at {self.sd_config.git_path}."
+                f"Found .git dir at {self.sd_config.git_path}."
             )
             self.sd_config.nested_project = False
         elif (self.project_root.parent / ".git").exists():
             self.sd_config.git_path = self.sd_config.project_root.parent
             plugin_utils.write_output(
-                self.sd_config, f"Found .git dir at {self.sd_config.git_path}."
+                f"Found .git dir at {self.sd_config.git_path}."
             )
             self.sd_config.nested_project = True
         else:
             error_msg = "Could not find a .git/ directory."
             error_msg += f"\n  Looked in {self.sd_config.project_root} and in {self.sd_config.project_root.parent}."
-            raise plugin_utils.SimpleDeployCommandError(self.sd_config, error_msg)
+            raise plugin_utils.SimpleDeployCommandError(error_msg)
 
     def _check_git_status(self):
         """Make sure all non-simple_deploy changes have already been committed.
@@ -356,24 +356,24 @@ class Command(BaseCommand):
         """
         if self.ignore_unclean_git:
             msg = "Ignoring git status."
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
             return
 
         cmd = "git status --porcelain"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         status_output = output_obj.stdout.decode()
-        plugin_utils.log_info(self.sd_config, f"{status_output}")
+        plugin_utils.log_info(f"{status_output}")
 
         cmd = "git diff --unified=0"
-        output_obj = plugin_utils.run_quick_command(self.sd_config, cmd)
+        output_obj = plugin_utils.run_quick_command(cmd)
         diff_output = output_obj.stdout.decode()
-        plugin_utils.log_info(self.sd_config, f"{diff_output}\n")
+        plugin_utils.log_info(f"{diff_output}\n")
 
         proceed = sd_utils.check_status_output(status_output, diff_output)
 
         if proceed:
             msg = "No uncommitted changes, other than simple_deploy work."
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
         else:
             self._raise_unclean_error()
 
@@ -383,7 +383,7 @@ class Command(BaseCommand):
         if self.sd_config.automate_all:
             error_msg += sd_messages.unclean_git_automate_all
 
-        raise plugin_utils.SimpleDeployCommandError(self.sd_config, error_msg)
+        raise plugin_utils.SimpleDeployCommandError(error_msg)
 
     def _ignore_sd_logs(self):
         """Add log dir to .gitignore.
@@ -397,10 +397,10 @@ class Command(BaseCommand):
             # Make the .gitignore file, and add log directory.
             gitignore_path.write_text(ignore_msg, encoding="utf-8")
             plugin_utils.write_output(
-                self.sd_config, "No .gitignore file found; created .gitignore."
+                "No .gitignore file found; created .gitignore."
             )
             plugin_utils.write_output(
-                self.sd_config, "Added simple_deploy_logs/ to .gitignore."
+                "Added simple_deploy_logs/ to .gitignore."
             )
         else:
             # Append log directory to .gitignore if it's not already there.
@@ -409,7 +409,7 @@ class Command(BaseCommand):
                 contents += f"\n{ignore_msg}"
                 gitignore_path.write_text(contents)
                 plugin_utils.write_output(
-                    self.sd_config, "Added simple_deploy_logs/ to .gitignore"
+                    "Added simple_deploy_logs/ to .gitignore"
                 )
 
     def _get_dep_man_approach(self):
@@ -439,7 +439,7 @@ class Command(BaseCommand):
         error_msg = (
             f"Couldn't find any specified requirements in {self.sd_config.git_path}."
         )
-        raise plugin_utils.SimpleDeployCommandError(self.sd_config, error_msg)
+        raise plugin_utils.SimpleDeployCommandError(error_msg)
 
     def _check_using_poetry(self):
         """Check if the project appears to be using poetry.
@@ -470,7 +470,7 @@ class Command(BaseCommand):
             List[str]: List of strings, each representing a requirement.
         """
         msg = "Checking current project requirements..."
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
 
         if self.sd_config.pkg_manager == "req_txt":
             self.sd_config.req_txt_path = self.sd_config.git_path / "requirements.txt"
@@ -488,10 +488,10 @@ class Command(BaseCommand):
 
         # Report findings.
         msg = "  Found existing dependencies:"
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
         for requirement in requirements:
             msg = f"    {requirement}"
-            plugin_utils.write_output(self.sd_config, msg)
+            plugin_utils.write_output(msg)
 
         return requirements
 
@@ -502,8 +502,8 @@ class Command(BaseCommand):
         requirements. If it's missing, platforms will reject the push.
         """
         msg = "\nLooking for django-simple-deploy in requirements..."
-        plugin_utils.write_output(self.sd_config, msg)
-        plugin_utils.add_package(self.sd_config, "django-simple-deploy")
+        plugin_utils.write_output(msg)
+        plugin_utils.add_package("django-simple-deploy")
 
     def _check_required_hooks(self, pm):
         """Check that all required hooks are implemeted by plugin.
@@ -551,17 +551,17 @@ class Command(BaseCommand):
         if not supported:
             msg = "\nThis platform does not support automated deployments."
             msg += "\nYou may want to try again without the --automate-all flag."
-            raise plugin_utils.SimpleDeployCommandError(self.sd_config, msg)
+            raise plugin_utils.SimpleDeployCommandError(msg)
 
         # Confirm the user wants to automate all steps.
         msg = pm.hook.simple_deploy_get_automate_all_msg()[0]
 
-        plugin_utils.write_output(self.sd_config, msg)
+        plugin_utils.write_output(msg)
         confirmed = plugin_utils.get_confirmation(self.sd_config)
 
         if confirmed:
-            plugin_utils.write_output(self.sd_config, "Automating all steps...")
+            plugin_utils.write_output("Automating all steps...")
         else:
             # Quit with a message, but don't raise an error.
-            plugin_utils.write_output(self.sd_config, sd_messages.cancel_automate_all)
+            plugin_utils.write_output(sd_messages.cancel_automate_all)
             sys.exit()

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -106,7 +106,7 @@ class Command(BaseCommand):
         # platform-specific plugins.
         self.sd_config = SDConfig(self.stdout)
         plugin_utils.init(self.sd_config)
-        
+
         plugin_utils.write_output(
             "Configuring project for deployment...", skip_logging=True
         )
@@ -523,7 +523,7 @@ class Command(BaseCommand):
         for hook in required_hooks:
             if hook not in callers:
                 msg = f"\nPlugin missing required hook implementation: {hook}()"
-                raise plugin_utils.SimpleDeployCommandError(self, msg)
+                raise plugin_utils.SimpleDeployCommandError(msg)
 
         # If plugin supports automate_all, make sure a confirmation message is provided.
         if not pm.hook.simple_deploy_automate_all_supported()[0]:
@@ -532,7 +532,7 @@ class Command(BaseCommand):
         hook = "simple_deploy_get_automate_all_msg"
         if hook not in callers:
             msg = f"\nPlugin missing required hook implementation: {hook}()"
-            raise plugin_utils.SimpleDeployCommandError(self, msg)
+            raise plugin_utils.SimpleDeployCommandError(msg)
 
     def _confirm_automate_all(self, pm):
         """Confirm the user understands what --automate-all does.

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -105,6 +105,8 @@ class Command(BaseCommand):
         # Create a config object here. This is what's shared with
         # platform-specific plugins.
         self.sd_config = SDConfig(self.stdout)
+        plugin_utils.init(self.sd_config)
+        
         plugin_utils.write_output(
             self.sd_config, "Configuring project for deployment...", skip_logging=True
         )

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -35,8 +35,8 @@ class SimpleDeployCommandError(CommandError):
     """
 
     def __init__(self, sd_config, message):
-        log_info(sd_config, "\nSimpleDeployCommandError:")
-        log_info(sd_config, message)
+        log_info("\nSimpleDeployCommandError:")
+        log_info(message)
         super().__init__(message)
 
 
@@ -58,25 +58,25 @@ def add_file(path, contents):
     to overwrite file.
     """
 
-    write_output(sd_config, f"\n  Looking in {path.parent} for {path.name}...")
+    write_output(f"\n  Looking in {path.parent} for {path.name}...")
 
     if path.exists():
-        proceed = get_confirmation(sd_config, sd_messages.file_found(path.name))
+        proceed = get_confirmation(sd_messages.file_found(path.name))
         if not proceed:
             raise SimpleDeployCommandError(
                 sd_config, sd_messages.file_replace_rejected(path.name)
             )
     else:
-        write_output(sd_config, f"    File {path.name} not found. Generating file...")
+        write_output(f"    File {path.name} not found. Generating file...")
 
     # File does not exist, or we are free to overwrite it.
     path.write_text(contents)
 
     msg = f"\n    Wrote {path.name} to {path}"
-    write_output(sd_config, msg)
+    write_output(msg)
 
 
-def modify_file(sd_config, path, contents):
+def modify_file(path, contents):
     """Modify an existing file.
 
     This function is meant for modifying a file that should already exist, such as
@@ -92,15 +92,15 @@ def modify_file(sd_config, path, contents):
     # Make sure file exists.
     if not path.exists():
         msg = f"File {path.as_posix()} does not exist."
-        raise SimpleDeployCommandError(sd_config, msg)
+        raise SimpleDeployCommandError(msg)
 
     # Rewrite file with new contents.
     path.write_text(contents)
     msg = f"  Modified file: {path.as_posix()}"
-    write_output(sd_config, msg)
+    write_output(msg)
 
 
-def add_dir(sd_config, path):
+def add_dir(path):
     """Write a new directory to the file.
 
     This function is meant to be used when adding new directories that don't
@@ -112,16 +112,16 @@ def add_dir(sd_config, path):
     Returns:
     - None
     """
-    write_output(sd_config, f"\n  Looking for {path.as_posix()}...")
+    write_output(f"\n  Looking for {path.as_posix()}...")
 
     if path.exists():
-        write_output(sd_config, f"    Found {path.as_posix()}")
+        write_output(f"    Found {path.as_posix()}")
     else:
         path.mkdir()
-        write_output(sd_config, f"    Added new directory: {path.as_posix()}")
+        write_output(f"    Added new directory: {path.as_posix()}")
 
 
-def get_numbered_choice(sd_config, prompt, valid_choices, quit_message):
+def get_numbered_choice(prompt, valid_choices, quit_message):
     """Select from a numbered list of choices.
 
     This is used, for example, to select from a number of apps that the user
@@ -131,32 +131,32 @@ def get_numbered_choice(sd_config, prompt, valid_choices, quit_message):
 
     while True:
         # Show prompt and get selection.
-        log_info(sd_config, prompt)
+        log_info(prompt)
 
         selection = input(prompt)
-        log_info(sd_config, selection)
+        log_info(selection)
 
         if selection.lower() in ["q", "quit"]:
-            raise SimpleDeployCommandError(sd_config, quit_message)
+            raise SimpleDeployCommandError(quit_message)
 
         # Make sure they entered a number
         try:
             selection = int(selection)
         except ValueError:
             msg = "Please enter a number from the list of choices."
-            write_output(sd_config, msg)
+            write_output(msg)
             continue
 
         # Validate selection.
         if selection not in valid_choices:
             msg = "  Invalid selection. Please try again."
-            write_output(sd_config, msg)
+            write_output(msg)
             continue
 
         return selection
 
 
-def run_quick_command(sd_config, cmd, check=False, skip_logging=False):
+def run_quick_command(cmd, check=False, skip_logging=False):
     """Run a command that should finish quickly.
 
     Commands that should finish quickly can be run more simply than commands that
@@ -177,7 +177,7 @@ def run_quick_command(sd_config, cmd, check=False, skip_logging=False):
         instead of returning a CompletedProcess instance with an error code set.
     """
     if not skip_logging:
-        log_info(sd_config, f"\n{cmd}")
+        log_info(f"\n{cmd}")
 
     if sd_config.on_windows:
         output = subprocess.run(cmd, shell=True, capture_output=True)
@@ -188,7 +188,7 @@ def run_quick_command(sd_config, cmd, check=False, skip_logging=False):
     return output
 
 
-def run_slow_command(sd_config, cmd, skip_logging=False):
+def run_slow_command(cmd, skip_logging=False):
     """Run a command that may take some time.
 
     For commands that may take a while, we need to stream output to the user, rather
@@ -204,7 +204,7 @@ def run_slow_command(sd_config, cmd, skip_logging=False):
     # over p.stdout misses stderr. Maybe combine the loops with zip()? SO posts on
     # this topic date back to Python2/3 days.
     if not skip_logging:
-        log_info(sd_config, f"\n{cmd}")
+        log_info(f"\n{cmd}")
 
     cmd_parts = cmd.split()
     with subprocess.Popen(
@@ -215,7 +215,7 @@ def run_slow_command(sd_config, cmd, skip_logging=False):
         shell=sd_config.use_shell,
     ) as p:
         for line in p.stderr:
-            write_output(sd_config, line, skip_logging=skip_logging)
+            write_output(line, skip_logging=skip_logging)
 
     if p.returncode != 0:
         raise subprocess.CalledProcessError(p.returncode, p.args)
@@ -238,19 +238,19 @@ def get_confirmation(
 
     # If doing e2e testing, always return True.
     if sd_config.e2e_testing:
-        write_output(sd_config, prompt, skip_logging=skip_logging)
+        write_output(prompt, skip_logging=skip_logging)
         msg = "  Confirmed for e2e testing..."
-        write_output(sd_config, msg, skip_logging=skip_logging)
+        write_output(msg, skip_logging=skip_logging)
         return True
 
     if sd_config.unit_testing:
-        write_output(sd_config, prompt, skip_logging=skip_logging)
+        write_output(prompt, skip_logging=skip_logging)
         msg = "  Confirmed for unit testing..."
-        write_output(sd_config, msg, skip_logging=skip_logging)
+        write_output(msg, skip_logging=skip_logging)
         return True
 
     while True:
-        write_output(sd_config, prompt, skip_logging=skip_logging)
+        write_output(prompt, skip_logging=skip_logging)
         confirmed = input()
 
         # Log user's response before processing it.
@@ -268,7 +268,7 @@ def get_confirmation(
             )
 
 
-def check_settings(sd_config, platform_name, start_line, msg_found, msg_cant_overwrite):
+def check_settings(platform_name, start_line, msg_found, msg_cant_overwrite):
     """Check if a platform-specific settings block already exists.
 
     If so, ask if we can overwrite that block. This is much simpler than trying to
@@ -287,21 +287,21 @@ def check_settings(sd_config, platform_name, start_line, msg_found, msg_cant_ove
     m = re.match(re_platform_settings, settings_text, re.DOTALL)
 
     if not m:
-        log_info(sd_config, f"No {platform_name}-specific settings block found.")
+        log_info(f"No {platform_name}-specific settings block found.")
         return
 
     # A platform-specific settings block exists. Get permission to overwrite it.
-    if not get_confirmation(sd_config, msg_found):
-        raise SimpleDeployCommandError(sd_config, msg_cant_overwrite)
+    if not get_confirmation(msg_found):
+        raise SimpleDeployCommandError(msg_cant_overwrite)
 
     # Platform-specific settings exist, but we can remove them and start fresh.
     sd_config.settings_path.write_text(m.group(1))
 
     msg = f"  Removed existing {platform_name}-specific settings block."
-    write_output(sd_config, msg)
+    write_output(msg)
 
 
-def write_output(sd_config, output, write_to_console=True, skip_logging=False):
+def write_output(output, write_to_console=True, skip_logging=False):
     """Write output to the appropriate places.
 
     Typically, this is used for writing output to the console as the configuration
@@ -321,10 +321,10 @@ def write_output(sd_config, output, write_to_console=True, skip_logging=False):
         sd_config.stdout.write(output_str)
 
     if not skip_logging:
-        log_info(sd_config, output_str)
+        log_info(output_str)
 
 
-def log_info(sd_config, output):
+def log_info(output):
     """Log output, which may be a string or CompletedProcess instance."""
     if sd_config.log_output:
         output_str = get_string_from_output(output)
@@ -339,18 +339,18 @@ def commit_changes(sd_config):
     if not sd_config.automate_all:
         return
 
-    write_output(sd_config, "  Committing changes...")
+    write_output("  Committing changes...")
 
     cmd = "git add ."
-    output = run_quick_command(sd_config, cmd)
-    write_output(sd_config, output)
+    output = run_quick_command(cmd)
+    write_output(output)
 
     cmd = 'git commit -m "Configured project for deployment."'
-    output = run_quick_command(sd_config, cmd)
-    write_output(sd_config, output)
+    output = run_quick_command(cmd)
+    write_output(output)
 
 
-def add_packages(sd_config, package_list):
+def add_packages(package_list):
     """Add a set of packages to the project's requirements.
 
     This is a simple wrapper for add_package(), to make it easier to add multiple
@@ -361,10 +361,10 @@ def add_packages(sd_config, package_list):
         None
     """
     for package in package_list:
-        add_package(sd_config, package)
+        add_package(package)
 
 
-def add_package(sd_config, package_name, version=""):
+def add_package(package_name, version=""):
     """Add a package to the project's requirements, if not already present.
 
     Handles calls with version information with pip formatting:
@@ -375,10 +375,10 @@ def add_package(sd_config, package_name, version=""):
     Returns:
         None
     """
-    write_output(sd_config, f"\nLooking for {package_name}...")
+    write_output(f"\nLooking for {package_name}...")
 
     if package_name in sd_config.requirements:
-        write_output(sd_config, f"  Found {package_name} in requirements file.")
+        write_output(f"  Found {package_name} in requirements file.")
         return
 
     if sd_config.pkg_manager == "pipenv":
@@ -389,7 +389,7 @@ def add_package(sd_config, package_name, version=""):
     else:
         add_req_txt_pkg(sd_config.req_txt_path, package_name, version)
 
-    write_output(sd_config, f"  Added {package_name} to requirements file.")
+    write_output(f"  Added {package_name} to requirements file.")
 
 
 # --- Utilities that do not require an instance of SDConfig ---
@@ -479,7 +479,7 @@ def _check_poetry_deploy_group(sd_config):
     except KeyError:
         create_poetry_deploy_group(sd_config.pyprojecttoml_path)
         msg = "    Added optional deploy group to pyproject.toml."
-        write_output(sd_config, msg)
+        write_output(msg)
 
 
 def create_poetry_deploy_group(pptoml_path):

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -16,9 +16,10 @@ from .. import sd_messages
 
 # --- Utilities that require an instance of Command ---
 
-# def init(sd_config):
-#     """Make sd_config instance available to all functions in this module."""
-#     global sd_config
+def init(config):
+    """Make sd_config instance available to all functions in this module."""
+    global sd_config
+    sd_config = config
 
 
 
@@ -39,7 +40,7 @@ class SimpleDeployCommandError(CommandError):
         super().__init__(message)
 
 
-def add_file(sd_config, path, contents):
+def add_file(path, contents):
     """Add a new file to the project.
 
     This function is meant to be used when adding new files that don't typically

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -34,7 +34,7 @@ class SimpleDeployCommandError(CommandError):
     SimpleDeployCommandError.
     """
 
-    def __init__(self, sd_config, message):
+    def __init__(self, message):
         log_info("\nSimpleDeployCommandError:")
         log_info(message)
         super().__init__(message)
@@ -64,7 +64,7 @@ def add_file(path, contents):
         proceed = get_confirmation(sd_messages.file_found(path.name))
         if not proceed:
             raise SimpleDeployCommandError(
-                sd_config, sd_messages.file_replace_rejected(path.name)
+                sd_messages.file_replace_rejected(path.name)
             )
     else:
         write_output(f"    File {path.name} not found. Generating file...")
@@ -222,7 +222,7 @@ def run_slow_command(cmd, skip_logging=False):
 
 
 def get_confirmation(
-    sd_config, msg="Are you sure you want to do this?", skip_logging=False
+    msg="Are you sure you want to do this?", skip_logging=False
 ):
     """Get confirmation for an action.
 
@@ -255,7 +255,7 @@ def get_confirmation(
 
         # Log user's response before processing it.
         write_output(
-            sd_config, confirmed, skip_logging=skip_logging, write_to_console=False
+            confirmed, skip_logging=skip_logging, write_to_console=False
         )
 
         if confirmed.lower() in ("y", "yes"):
@@ -264,7 +264,7 @@ def get_confirmation(
             return False
         else:
             write_output(
-                sd_config, "  Please answer yes or no.", skip_logging=skip_logging
+                "  Please answer yes or no.", skip_logging=skip_logging
             )
 
 
@@ -331,7 +331,7 @@ def log_info(output):
         log_output_string(output_str)
 
 
-def commit_changes(sd_config):
+def commit_changes():
     """Commit changes that have been made to the project.
 
     This should only be called when automate_all is being used.
@@ -384,7 +384,7 @@ def add_package(package_name, version=""):
     if sd_config.pkg_manager == "pipenv":
         add_pipenv_pkg(sd_config.pipfile_path, package_name, version)
     elif sd_config.pkg_manager == "poetry":
-        _check_poetry_deploy_group(sd_config)
+        _check_poetry_deploy_group()
         add_poetry_pkg(sd_config.pyprojecttoml_path, package_name, version)
     else:
         add_req_txt_pkg(sd_config.req_txt_path, package_name, version)
@@ -471,7 +471,7 @@ def add_pipenv_pkg(pipfile_path, package, version):
     pipfile_path.write_text(data_str)
 
 
-def _check_poetry_deploy_group(sd_config):
+def _check_poetry_deploy_group():
     """Make sure a deploy group exists in pyproject.toml."""
     pptoml_data = toml.load(sd_config.pyprojecttoml_path)
     try:

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -16,6 +16,11 @@ from .. import sd_messages
 
 # --- Utilities that require an instance of Command ---
 
+# def init(sd_config):
+#     """Make sd_config instance available to all functions in this module."""
+#     global sd_config
+
+
 
 class SimpleDeployCommandError(CommandError):
     """Simple wrapper around CommandError, to facilitate consistent

--- a/simple_deploy/management/commands/utils/sd_config.py
+++ b/simple_deploy/management/commands/utils/sd_config.py
@@ -1,3 +1,6 @@
+from .plugin_utils import SimpleDeployCommandError
+
+
 class SDConfig:
     """Class for managing attributes of Command that need to be shared with plugins."""
 
@@ -32,3 +35,22 @@ class SDConfig:
         self.e2e_testing = None
         self.unit_testing = None
         self.stdout = stdout
+
+    def validate(self):
+        """Make sure all required attributes have been defined."""
+        if not self.pkg_manager:
+            msg = "Could not identify dependency management system in use."
+            raise SimpleDeployCommandError(msg)
+
+        if self.requirements is None:
+            msg = "Could not identify project dependencies."
+            raise SimpleDeployCommandError(msg)
+
+        if self.project_root is None:
+            msg = "Could not identify project's root directory."
+            raise SimpleDeployCommandError(msg)
+
+        if self.settings_path is None:
+            msg = "Could not identify path to settings.py."
+            raise SimpleDeployCommandError(msg)
+        

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import filecmp
+import sys
 
 from simple_deploy.management.commands.utils import sd_utils
 from simple_deploy.management.commands.utils import plugin_utils
@@ -151,3 +152,22 @@ def test_add_pipenv_pkg(tmp_path):
     plugin_utils.add_pipenv_pkg(tmp_pipfile, "awesome-deployment-package", "")
     ref_file = Path(__file__).parent / "reference_files" / "Pipfile"
     assert filecmp.cmp(tmp_pipfile, ref_file)
+
+
+# --- Tests for functions that require sd_config ---
+
+def test_add_file(tmp_path, mock_sdconfig):
+    """Test utility for adding a file."""
+    contents = "Sample file contents.\n"
+    path = tmp_path / "test_add_file.txt"
+
+    assert not path.exists()
+
+    mock_sdconfig.unit_testing = "True"
+    mock_sdconfig.stdout = sys.stdout
+    plugin_utils.add_file(mock_sdconfig, path, contents)
+
+    assert path.exists()
+
+    contents_from_file = path.read_text()
+    assert contents_from_file == contents

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -165,7 +165,8 @@ def test_add_file(tmp_path, mock_sdconfig):
 
     mock_sdconfig.unit_testing = "True"
     mock_sdconfig.stdout = sys.stdout
-    plugin_utils.add_file(mock_sdconfig, path, contents)
+    plugin_utils.init(mock_sdconfig)
+    plugin_utils.add_file(path, contents)
 
     assert path.exists()
 


### PR DESCRIPTION
Everyone says not to use globals, but it sure seems to make sense in this context. This requires calling `plugin_utils.init()` in `Command`, and then sd_config no longer needs to be passed from sd to plugins. Plugin util functions are much simpler, and don't have nearly as much cruft. For example:

`plugin_utils.write_output(msg)`

instead of

`plugin_utils.write_output(self.sd_config, msg)`

There are a number of options for protecting the config instance if it becomes necessary.