### PR TITLE
Avoid global in usage of sd_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The goal for the 0.7 series is to support an internal plugin model. There should
 - `SDConfig` instance is now a global in `plugin_utils`. Despite the oft-repeated advice not to use globals, it really seems to make sense in this context. It simplifies most plugin utility function signatures. For example: `plugin_utils.write_output(self.sd_config, msg)` is now `plugin_utils.write_output(msg)`. There are numerous ways to protect the config instance if the need arises, or choose a different non-globabl approach with this as a better starting point.
 - `SDConfig.validate()` checks that attributes required by all plugins have been set.
 - Plugins import `sd_config` directly. This simplifies the use of `sd_config` significantly in plugins. For example, `self.sd_config.automate_all` becomes `sd_config.automate_all`. Also, core no longer needs to pass anything off directly to plugins.
+- `SDConfig` is instantiated once, at the module level, in `plugin_utils`. It's imported directly into simple_deploy.py and each plugin's `platform_deployer` module. Attributes are set by `Command`, and read by plugins as needed.
+- `SimpleDeployCommandError` is moved to its own module, and imported directly into any module that needs it.
 
 
 ### 0.7.2

--- a/simple_deploy/management/commands/fly_io/platform_deployer.py
+++ b/simple_deploy/management/commands/fly_io/platform_deployer.py
@@ -398,9 +398,7 @@ class PlatformDeployer:
             if sd_config.automate_all:
                 self.app_name = self._create_flyio_app()
             else:
-                raise SimpleDeployCommandError(
-                    platform_msgs.no_project_name
-                )
+                raise SimpleDeployCommandError(platform_msgs.no_project_name)
         elif len(project_names) == 1:
             # Only one app name found. Confirm we can deploy to this app.
             project_name = project_names[0]
@@ -413,9 +411,7 @@ class PlatformDeployer:
             elif sd_config.automate_all:
                 self.app_name = self._create_flyio_app()
             else:
-                raise SimpleDeployCommandError(
-                    platform_msgs.no_project_name
-                )
+                raise SimpleDeployCommandError(platform_msgs.no_project_name)
         else:
             # More than one undeployed app found. `apps list` doesn't show
             # much specific information for undeployed apps. For exmaple we

--- a/simple_deploy/management/commands/fly_io/platform_deployer.py
+++ b/simple_deploy/management/commands/fly_io/platform_deployer.py
@@ -19,6 +19,7 @@ from . import deploy_messages as platform_msgs
 
 from ..utils import plugin_utils
 from ..utils.plugin_utils import sd_config
+from ..utils.command_errors import SimpleDeployCommandError
 
 
 class PlatformDeployer:
@@ -307,13 +308,13 @@ class PlatformDeployer:
         try:
             output_obj = plugin_utils.run_quick_command(cmd)
         except FileNotFoundError:
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cli_not_installed)
+            raise SimpleDeployCommandError(platform_msgs.cli_not_installed)
 
         plugin_utils.log_info(output_obj)
 
         # DEV: Note which OS this block runs on; I believe it's macOS.
         if output_obj.returncode:
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cli_not_installed)
+            raise SimpleDeployCommandError(platform_msgs.cli_not_installed)
 
         # Check that user is authenticated.
         cmd = "fly auth whoami --json"
@@ -321,7 +322,7 @@ class PlatformDeployer:
 
         error_msg = "Error: No access token available."
         if error_msg in output_obj.stderr.decode():
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cli_logged_out)
+            raise SimpleDeployCommandError(platform_msgs.cli_logged_out)
 
         # Show current authenticated fly user.
         whoami_json = json.loads(output_obj.stdout.decode())
@@ -397,7 +398,7 @@ class PlatformDeployer:
             if sd_config.automate_all:
                 self.app_name = self._create_flyio_app()
             else:
-                raise plugin_utils.SimpleDeployCommandError(
+                raise SimpleDeployCommandError(
                     platform_msgs.no_project_name
                 )
         elif len(project_names) == 1:
@@ -412,7 +413,7 @@ class PlatformDeployer:
             elif sd_config.automate_all:
                 self.app_name = self._create_flyio_app()
             else:
-                raise plugin_utils.SimpleDeployCommandError(
+                raise SimpleDeployCommandError(
                     platform_msgs.no_project_name
                 )
         else:
@@ -481,7 +482,7 @@ class PlatformDeployer:
         try:
             self.app_name = app_dict["Name"]
         except KeyError:
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.create_app_failed)
+            raise SimpleDeployCommandError(platform_msgs.create_app_failed)
         else:
             msg = f"  Created new app: {self.app_name}"
             plugin_utils.write_output(msg)
@@ -675,7 +676,7 @@ class PlatformDeployer:
             # Note: This path has only been tested once, by manually adding
             # "dummy-user" to the list of db users."
             msg = platform_msgs.cant_use_db(self.db_name, self.db_users)
-            raise plugin_utils.SimpleDeployCommandError(msg)
+            raise SimpleDeployCommandError(msg)
 
     def _confirm_use_attached_db(self):
         """Confirm it's okay to use db that's already attached to this app.
@@ -693,7 +694,7 @@ class PlatformDeployer:
         if not plugin_utils.get_confirmation(msg):
             # Permission to use this db denied. Can't simply create a new db,
             # because the name we'd use is already taken.
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cancel_no_db)
+            raise SimpleDeployCommandError(platform_msgs.cancel_no_db)
 
     def _confirm_use_unattached_db(self):
         """Confirm it's okay to use db whose name matches this app, but hasn't
@@ -721,7 +722,7 @@ class PlatformDeployer:
             # Permission to use this db denied.
             # Can't simply create a new db, because the name we'd use is
             # already taken.
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cancel_no_db)
+            raise SimpleDeployCommandError(platform_msgs.cancel_no_db)
 
     def _confirm_create_db(self, db_cmd):
         """Confirm the user wants a database created on their behalf.
@@ -742,7 +743,7 @@ class PlatformDeployer:
             sd_config.stdout.write("  Creating database...")
         else:
             # Quit and invite the user to create a database manually.
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cancel_no_db)
+            raise SimpleDeployCommandError(platform_msgs.cancel_no_db)
 
     def _attach_db(self):
         """Attach the database to the app."""

--- a/simple_deploy/management/commands/heroku/platform_deployer.py
+++ b/simple_deploy/management/commands/heroku/platform_deployer.py
@@ -5,13 +5,13 @@ from pathlib import Path
 from itertools import takewhile
 
 from django.conf import settings
-from django.core.management.base import CommandError
 from django.core.management.utils import get_random_secret_key
 from django.utils.crypto import get_random_string
 from django.utils.safestring import mark_safe
 
 from ..utils import plugin_utils
 from ..utils.plugin_utils import sd_config
+from ..utils.command_errors import SimpleDeployCommandError
 
 from . import deploy_messages as platform_msgs
 
@@ -345,14 +345,14 @@ class PlatformDeployer:
             output_obj = plugin_utils.run_quick_command(cmd)
         except FileNotFoundError:
             # This generates a FileNotFoundError on Linux (Ubuntu) if CLI not installed.
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cli_not_installed)
+            raise SimpleDeployCommandError(platform_msgs.cli_not_installed)
 
         plugin_utils.log_info(output_obj)
 
         # The returncode for a successful command is 0, so anything truthy means the
         # command errored out.
         if output_obj.returncode:
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cli_not_installed)
+            raise SimpleDeployCommandError(platform_msgs.cli_not_installed)
 
     def _check_cli_authenticated(self):
         """Verify the user has authenticated with the CLI.
@@ -375,7 +375,7 @@ class PlatformDeployer:
         if ("Error: Invalid credentials provided" in output_str) or (
             "Error: not logged in" in output_str
         ):
-            raise plugin_utils.SimpleDeployCommandError(
+            raise SimpleDeployCommandError(
                 platform_msgs.cli_not_authenticated
             )
 
@@ -411,7 +411,7 @@ class PlatformDeployer:
 
         # If output_str is emtpy, there is no heroku app.
         if not output_str:
-            raise plugin_utils.SimpleDeployCommandError(
+            raise SimpleDeployCommandError(
                 platform_msgs.no_heroku_app_detected
             )
 

--- a/simple_deploy/management/commands/heroku/platform_deployer.py
+++ b/simple_deploy/management/commands/heroku/platform_deployer.py
@@ -375,9 +375,7 @@ class PlatformDeployer:
         if ("Error: Invalid credentials provided" in output_str) or (
             "Error: not logged in" in output_str
         ):
-            raise SimpleDeployCommandError(
-                platform_msgs.cli_not_authenticated
-            )
+            raise SimpleDeployCommandError(platform_msgs.cli_not_authenticated)
 
     def _check_heroku_project_available(self):
         """Verify that a Heroku project is available to push to.
@@ -411,9 +409,7 @@ class PlatformDeployer:
 
         # If output_str is emtpy, there is no heroku app.
         if not output_str:
-            raise SimpleDeployCommandError(
-                platform_msgs.no_heroku_app_detected
-            )
+            raise SimpleDeployCommandError(platform_msgs.no_heroku_app_detected)
 
         # Parse output for app_name.
         self.apps_list = json.loads(output_str)

--- a/simple_deploy/management/commands/platform_sh/platform_deployer.py
+++ b/simple_deploy/management/commands/platform_sh/platform_deployer.py
@@ -309,17 +309,11 @@ class PlatformDeployer:
         if not output_str:
             output_str = output_obj.stderr.decode()
             if "LoginRequiredException" in output_str:
-                raise SimpleDeployCommandError(
-                    platform_msgs.login_required
-                )
+                raise SimpleDeployCommandError(platform_msgs.login_required)
             elif "ProjectNotFoundException" in output_str:
-                raise SimpleDeployCommandError(
-                    platform_msgs.no_project_name
-                )
+                raise SimpleDeployCommandError(platform_msgs.no_project_name)
             elif "RootNotFoundException" in output_str:
-                raise SimpleDeployCommandError(
-                    platform_msgs.no_project_name
-                )
+                raise SimpleDeployCommandError(platform_msgs.no_project_name)
             else:
                 error_msg = platform_msgs.unknown_error
                 error_msg += platform_msgs.cli_not_installed

--- a/simple_deploy/management/commands/platform_sh/platform_deployer.py
+++ b/simple_deploy/management/commands/platform_sh/platform_deployer.py
@@ -14,6 +14,7 @@ from django.utils.safestring import mark_safe
 
 from ..utils import plugin_utils
 from ..utils.plugin_utils import sd_config
+from ..utils.command_errors import SimpleDeployCommandError
 
 from . import deploy_messages as platform_msgs
 from . import utils as plsh_utils
@@ -115,7 +116,7 @@ class PlatformDeployer:
             plugin_utils.run_slow_command(cmd)
         except subprocess.CalledProcessError as e:
             error_msg = platform_msgs.unknown_create_error(e)
-            raise plugin_utils.SimpleDeployCommandError(error_msg)
+            raise SimpleDeployCommandError(error_msg)
 
     def _modify_settings(self):
         """Add platformsh-specific settings.
@@ -257,7 +258,7 @@ class PlatformDeployer:
         try:
             output_obj = plugin_utils.run_quick_command(cmd)
         except FileNotFoundError:
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cli_not_installed)
+            raise SimpleDeployCommandError(platform_msgs.cli_not_installed)
 
         plugin_utils.log_info(output_obj)
 
@@ -266,7 +267,7 @@ class PlatformDeployer:
         output_obj = plugin_utils.run_quick_command(cmd)
 
         if "Authentication is required." in output_obj.stderr.decode():
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.cli_logged_out)
+            raise SimpleDeployCommandError(platform_msgs.cli_logged_out)
 
     def _get_platformsh_project_name(self):
         """Get the deployed project name.
@@ -308,21 +309,21 @@ class PlatformDeployer:
         if not output_str:
             output_str = output_obj.stderr.decode()
             if "LoginRequiredException" in output_str:
-                raise plugin_utils.SimpleDeployCommandError(
+                raise SimpleDeployCommandError(
                     platform_msgs.login_required
                 )
             elif "ProjectNotFoundException" in output_str:
-                raise plugin_utils.SimpleDeployCommandError(
+                raise SimpleDeployCommandError(
                     platform_msgs.no_project_name
                 )
             elif "RootNotFoundException" in output_str:
-                raise plugin_utils.SimpleDeployCommandError(
+                raise SimpleDeployCommandError(
                     platform_msgs.no_project_name
                 )
             else:
                 error_msg = platform_msgs.unknown_error
                 error_msg += platform_msgs.cli_not_installed
-                raise plugin_utils.SimpleDeployCommandError(error_msg)
+                raise SimpleDeployCommandError(error_msg)
 
         # Pull deployed project name from output.
         lines = output_str.splitlines()
@@ -339,7 +340,7 @@ class PlatformDeployer:
             return project_name
 
         # Couldn't find a project name. Warn user, and tell them about override flag.
-        raise plugin_utils.SimpleDeployCommandError(platform_msgs.no_project_name)
+        raise SimpleDeployCommandError(platform_msgs.no_project_name)
 
     def _get_org_name(self):
         """Get the organization name associated with the user's Platform.sh account.
@@ -365,7 +366,7 @@ class PlatformDeployer:
 
         org_names = plsh_utils.get_org_names(output_str)
         if not org_names:
-            raise plugin_utils.SimpleDeployCommandError(platform_msgs.org_not_found)
+            raise SimpleDeployCommandError(platform_msgs.org_not_found)
 
         if len(org_names) == 1:
             # Get permission to use this org.
@@ -413,4 +414,4 @@ class PlatformDeployer:
             # Exit, with a message that configuration is still an option.
             msg = platform_msgs.cancel_plsh
             msg += platform_msgs.may_configure
-            raise plugin_utils.SimpleDeployCommandError(msg)
+            raise SimpleDeployCommandError(msg)

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -38,7 +38,9 @@ import toml
 from . import sd_messages
 from .utils import sd_utils
 from .utils import plugin_utils
-from .utils.sd_config import SDConfig
+# from .utils.sd_config import SDConfig
+from .utils.plugin_utils import sd_config
+from .utils.command_errors import SimpleDeployCommandError
 from . import cli
 
 from simple_deploy.plugins import pm
@@ -104,8 +106,9 @@ class Command(BaseCommand):
 
         # Create a config object here. This is what's shared with
         # platform-specific plugins.
-        self.sd_config = SDConfig(self.stdout)
-        plugin_utils.init(self.sd_config)
+        # self.sd_config = SDConfig(self.stdout)
+        # plugin_utils.init(self.sd_config)
+        sd_config.stdout = self.stdout
 
         plugin_utils.write_output(
             "Configuring project for deployment...", skip_logging=True
@@ -115,7 +118,7 @@ class Command(BaseCommand):
         # has been passed.
         self._parse_cli_options(options)
 
-        if self.sd_config.log_output:
+        if sd_config.log_output:
             self._start_logging()
             self._log_cli_args(options)
 
@@ -134,25 +137,25 @@ class Command(BaseCommand):
         self._confirm_automate_all(pm)
 
         # Validate sd_config before handing responsiblity off to plugin.
-        self.sd_config.validate()
+        sd_config.validate()
         pm.hook.simple_deploy_deploy()
 
     def _parse_cli_options(self, options):
         """Parse CLI options from simple_deploy command."""
 
         # Platform-agnostic arguments.
-        self.sd_config.automate_all = options["automate_all"]
+        sd_config.automate_all = options["automate_all"]
         self.platform = options["platform"]
-        self.sd_config.log_output = not (options["no_logging"])
+        sd_config.log_output = not (options["no_logging"])
         self.ignore_unclean_git = options["ignore_unclean_git"]
 
         # Platform.sh arguments.
-        self.sd_config.deployed_project_name = options["deployed_project_name"]
-        self.sd_config.region = options["region"]
+        sd_config.deployed_project_name = options["deployed_project_name"]
+        sd_config.region = options["region"]
 
         # Developer arguments.
-        self.sd_config.unit_testing = options["unit_testing"]
-        self.sd_config.e2e_testing = options["e2e_testing"]
+        sd_config.unit_testing = options["unit_testing"]
+        sd_config.e2e_testing = options["e2e_testing"]
 
     def _start_logging(self):
         """Set up for logging.
@@ -214,14 +217,14 @@ class Command(BaseCommand):
             SimpleDeployCommandError: If requested platform is supported.
         """
         if not self.platform:
-            raise plugin_utils.SimpleDeployCommandError(
+            raise SimpleDeployCommandError(
                 sd_messages.requires_platform_flag
             )
         elif self.platform in ["fly_io", "platform_sh", "heroku"]:
             plugin_utils.write_output(f"\nDeployment target: {self.platform}")
         else:
             error_msg = sd_messages.invalid_platform_msg(self.platform)
-            raise plugin_utils.SimpleDeployCommandError(error_msg)
+            raise SimpleDeployCommandError(error_msg)
 
     def _inspect_system(self):
         """Inspect the user's local system for relevant information.
@@ -232,14 +235,14 @@ class Command(BaseCommand):
 
         Linux is not mentioned because so far, if it works on macOS it works on Linux.
         """
-        self.sd_config.use_shell = False
-        self.sd_config.on_windows, self.sd_config.on_macos = False, False
+        sd_config.use_shell = False
+        sd_config.on_windows, sd_config.on_macos = False, False
         if platform.system() == "Windows":
-            self.sd_config.on_windows = True
-            self.sd_config.use_shell = True
+            sd_config.on_windows = True
+            sd_config.use_shell = True
             plugin_utils.log_info("Local platform identified: Windows")
         elif platform.system() == "Darwin":
-            self.sd_config.on_macos = True
+            sd_config.on_macos = True
             plugin_utils.log_info("Local platform identified: macOS")
 
     def _inspect_project(self):
@@ -263,34 +266,34 @@ class Command(BaseCommand):
         Returns:
             None
         """
-        self.sd_config.local_project_name = settings.ROOT_URLCONF.replace(".urls", "")
+        sd_config.local_project_name = settings.ROOT_URLCONF.replace(".urls", "")
         plugin_utils.log_info(
-            f"Local project name: {self.sd_config.local_project_name}"
+            f"Local project name: {sd_config.local_project_name}"
         )
 
-        self.sd_config.project_root = settings.BASE_DIR
-        plugin_utils.log_info(f"Project root: {self.sd_config.project_root}")
+        sd_config.project_root = settings.BASE_DIR
+        plugin_utils.log_info(f"Project root: {sd_config.project_root}")
 
         # Find .git location, and make sure there's a clean status.
         self._find_git_dir()
         self._check_git_status()
 
         # Now that we know where .git is, we can ignore simple_deploy logs.
-        if self.sd_config.log_output:
+        if sd_config.log_output:
             self._ignore_sd_logs()
 
-        self.sd_config.settings_path = (
-            self.sd_config.project_root
-            / self.sd_config.local_project_name
+        sd_config.settings_path = (
+            sd_config.project_root
+            / sd_config.local_project_name
             / "settings.py"
         )
 
         # Find out which package manager is being used: req_txt, poetry, or pipenv
-        self.sd_config.pkg_manager = self._get_dep_man_approach()
-        msg = f"Dependency management system: {self.sd_config.pkg_manager}"
+        sd_config.pkg_manager = self._get_dep_man_approach()
+        msg = f"Dependency management system: {sd_config.pkg_manager}"
         plugin_utils.write_output(msg)
 
-        self.sd_config.requirements = self._get_current_requirements()
+        sd_config.requirements = self._get_current_requirements()
 
     def _find_git_dir(self):
         """Find .git/ location.
@@ -305,7 +308,7 @@ class Command(BaseCommand):
         likely to be.
 
         Sets:
-            self.sd_config.git_path, self.sd_config.nested_project
+            sd_config.git_path, sd_config.nested_project
 
         Returns:
             None
@@ -313,18 +316,18 @@ class Command(BaseCommand):
         Raises:
             SimpleDeployCommandError: If .git/ dir not found.
         """
-        if (self.sd_config.project_root / ".git").exists():
-            self.sd_config.git_path = self.sd_config.project_root
-            plugin_utils.write_output(f"Found .git dir at {self.sd_config.git_path}.")
-            self.sd_config.nested_project = False
+        if (sd_config.project_root / ".git").exists():
+            sd_config.git_path = sd_config.project_root
+            plugin_utils.write_output(f"Found .git dir at {sd_config.git_path}.")
+            sd_config.nested_project = False
         elif (self.project_root.parent / ".git").exists():
-            self.sd_config.git_path = self.sd_config.project_root.parent
-            plugin_utils.write_output(f"Found .git dir at {self.sd_config.git_path}.")
-            self.sd_config.nested_project = True
+            sd_config.git_path = sd_config.project_root.parent
+            plugin_utils.write_output(f"Found .git dir at {sd_config.git_path}.")
+            sd_config.nested_project = True
         else:
             error_msg = "Could not find a .git/ directory."
-            error_msg += f"\n  Looked in {self.sd_config.project_root} and in {self.sd_config.project_root.parent}."
-            raise plugin_utils.SimpleDeployCommandError(error_msg)
+            error_msg += f"\n  Looked in {sd_config.project_root} and in {sd_config.project_root.parent}."
+            raise SimpleDeployCommandError(error_msg)
 
     def _check_git_status(self):
         """Make sure all non-simple_deploy changes have already been committed.
@@ -372,10 +375,10 @@ class Command(BaseCommand):
     def _raise_unclean_error(self):
         """Raise unclean git status error."""
         error_msg = sd_messages.unclean_git_status
-        if self.sd_config.automate_all:
+        if sd_config.automate_all:
             error_msg += sd_messages.unclean_git_automate_all
 
-        raise plugin_utils.SimpleDeployCommandError(error_msg)
+        raise SimpleDeployCommandError(error_msg)
 
     def _ignore_sd_logs(self):
         """Add log dir to .gitignore.
@@ -384,7 +387,7 @@ class Command(BaseCommand):
         """
         ignore_msg = "simple_deploy_logs/\n"
 
-        gitignore_path = self.sd_config.git_path / ".gitignore"
+        gitignore_path = sd_config.git_path / ".gitignore"
         if not gitignore_path.exists():
             # Make the .gitignore file, and add log directory.
             gitignore_path.write_text(ignore_msg, encoding="utf-8")
@@ -414,18 +417,18 @@ class Command(BaseCommand):
         Raises:
             SimpleDeployCommandError: If a pkg manager can't be identified.
         """
-        if (self.sd_config.git_path / "Pipfile").exists():
+        if (sd_config.git_path / "Pipfile").exists():
             return "pipenv"
         elif self._check_using_poetry():
             return "poetry"
-        elif (self.sd_config.git_path / "requirements.txt").exists():
+        elif (sd_config.git_path / "requirements.txt").exists():
             return "req_txt"
 
         # Exit if we haven't found any requirements.
         error_msg = (
-            f"Couldn't find any specified requirements in {self.sd_config.git_path}."
+            f"Couldn't find any specified requirements in {sd_config.git_path}."
         )
-        raise plugin_utils.SimpleDeployCommandError(error_msg)
+        raise SimpleDeployCommandError(error_msg)
 
     def _check_using_poetry(self):
         """Check if the project appears to be using poetry.
@@ -435,7 +438,7 @@ class Command(BaseCommand):
         Returns:
             bool: True if found, False if not found.
         """
-        path = self.sd_config.git_path / "pyproject.toml"
+        path = sd_config.git_path / "pyproject.toml"
         if not path.exists():
             return False
 
@@ -458,18 +461,18 @@ class Command(BaseCommand):
         msg = "Checking current project requirements..."
         plugin_utils.write_output(msg)
 
-        if self.sd_config.pkg_manager == "req_txt":
-            self.sd_config.req_txt_path = self.sd_config.git_path / "requirements.txt"
-            requirements = sd_utils.parse_req_txt(self.sd_config.req_txt_path)
-        elif self.sd_config.pkg_manager == "pipenv":
-            self.sd_config.pipfile_path = self.sd_config.git_path / "Pipfile"
-            requirements = sd_utils.parse_pipfile(self.sd_config.pipfile_path)
-        elif self.sd_config.pkg_manager == "poetry":
-            self.sd_config.pyprojecttoml_path = (
-                self.sd_config.git_path / "pyproject.toml"
+        if sd_config.pkg_manager == "req_txt":
+            sd_config.req_txt_path = sd_config.git_path / "requirements.txt"
+            requirements = sd_utils.parse_req_txt(sd_config.req_txt_path)
+        elif sd_config.pkg_manager == "pipenv":
+            sd_config.pipfile_path = sd_config.git_path / "Pipfile"
+            requirements = sd_utils.parse_pipfile(sd_config.pipfile_path)
+        elif sd_config.pkg_manager == "poetry":
+            sd_config.pyprojecttoml_path = (
+                sd_config.git_path / "pyproject.toml"
             )
             requirements = sd_utils.parse_pyproject_toml(
-                self.sd_config.pyprojecttoml_path
+                sd_config.pyprojecttoml_path
             )
 
         # Report findings.
@@ -509,7 +512,7 @@ class Command(BaseCommand):
         for hook in required_hooks:
             if hook not in callers:
                 msg = f"\nPlugin missing required hook implementation: {hook}()"
-                raise plugin_utils.SimpleDeployCommandError(msg)
+                raise SimpleDeployCommandError(msg)
 
         # If plugin supports automate_all, make sure a confirmation message is provided.
         if not pm.hook.simple_deploy_automate_all_supported()[0]:
@@ -518,7 +521,7 @@ class Command(BaseCommand):
         hook = "simple_deploy_get_automate_all_msg"
         if hook not in callers:
             msg = f"\nPlugin missing required hook implementation: {hook}()"
-            raise plugin_utils.SimpleDeployCommandError(msg)
+            raise SimpleDeployCommandError(msg)
 
     def _confirm_automate_all(self, pm):
         """Confirm the user understands what --automate-all does.
@@ -529,7 +532,7 @@ class Command(BaseCommand):
         If confirmation not granted, exit with a message, but no error.
         """
         # Placing this check here keeps the handle() method cleaner.
-        if not self.sd_config.automate_all:
+        if not sd_config.automate_all:
             return
 
         # Make sure this platform supports automate-all.
@@ -537,7 +540,7 @@ class Command(BaseCommand):
         if not supported:
             msg = "\nThis platform does not support automated deployments."
             msg += "\nYou may want to try again without the --automate-all flag."
-            raise plugin_utils.SimpleDeployCommandError(msg)
+            raise SimpleDeployCommandError(msg)
 
         # Confirm the user wants to automate all steps.
         msg = pm.hook.simple_deploy_get_automate_all_msg()[0]

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -39,7 +39,6 @@ from . import sd_messages
 from .utils import sd_utils
 from .utils import plugin_utils
 
-# from .utils.sd_config import SDConfig
 from .utils.plugin_utils import sd_config
 from .utils.command_errors import SimpleDeployCommandError
 from . import cli
@@ -104,11 +103,7 @@ class Command(BaseCommand):
         Add django-simple-deploy to project requirements.
         Call the platform-specific deploy() method.
         """
-
-        # Create a config object here. This is what's shared with
-        # platform-specific plugins.
-        # self.sd_config = SDConfig(self.stdout)
-        # plugin_utils.init(self.sd_config)
+        # Need to define stdout before the first call to write_output().
         sd_config.stdout = self.stdout
 
         plugin_utils.write_output(

--- a/simple_deploy/management/commands/simple_deploy.py
+++ b/simple_deploy/management/commands/simple_deploy.py
@@ -38,6 +38,7 @@ import toml
 from . import sd_messages
 from .utils import sd_utils
 from .utils import plugin_utils
+
 # from .utils.sd_config import SDConfig
 from .utils.plugin_utils import sd_config
 from .utils.command_errors import SimpleDeployCommandError
@@ -217,9 +218,7 @@ class Command(BaseCommand):
             SimpleDeployCommandError: If requested platform is supported.
         """
         if not self.platform:
-            raise SimpleDeployCommandError(
-                sd_messages.requires_platform_flag
-            )
+            raise SimpleDeployCommandError(sd_messages.requires_platform_flag)
         elif self.platform in ["fly_io", "platform_sh", "heroku"]:
             plugin_utils.write_output(f"\nDeployment target: {self.platform}")
         else:
@@ -267,9 +266,7 @@ class Command(BaseCommand):
             None
         """
         sd_config.local_project_name = settings.ROOT_URLCONF.replace(".urls", "")
-        plugin_utils.log_info(
-            f"Local project name: {sd_config.local_project_name}"
-        )
+        plugin_utils.log_info(f"Local project name: {sd_config.local_project_name}")
 
         sd_config.project_root = settings.BASE_DIR
         plugin_utils.log_info(f"Project root: {sd_config.project_root}")
@@ -283,9 +280,7 @@ class Command(BaseCommand):
             self._ignore_sd_logs()
 
         sd_config.settings_path = (
-            sd_config.project_root
-            / sd_config.local_project_name
-            / "settings.py"
+            sd_config.project_root / sd_config.local_project_name / "settings.py"
         )
 
         # Find out which package manager is being used: req_txt, poetry, or pipenv
@@ -425,9 +420,7 @@ class Command(BaseCommand):
             return "req_txt"
 
         # Exit if we haven't found any requirements.
-        error_msg = (
-            f"Couldn't find any specified requirements in {sd_config.git_path}."
-        )
+        error_msg = f"Couldn't find any specified requirements in {sd_config.git_path}."
         raise SimpleDeployCommandError(error_msg)
 
     def _check_using_poetry(self):
@@ -468,12 +461,8 @@ class Command(BaseCommand):
             sd_config.pipfile_path = sd_config.git_path / "Pipfile"
             requirements = sd_utils.parse_pipfile(sd_config.pipfile_path)
         elif sd_config.pkg_manager == "poetry":
-            sd_config.pyprojecttoml_path = (
-                sd_config.git_path / "pyproject.toml"
-            )
-            requirements = sd_utils.parse_pyproject_toml(
-                sd_config.pyprojecttoml_path
-            )
+            sd_config.pyprojecttoml_path = sd_config.git_path / "pyproject.toml"
+            requirements = sd_utils.parse_pyproject_toml(sd_config.pyprojecttoml_path)
 
         # Report findings.
         msg = "  Found existing dependencies:"

--- a/simple_deploy/management/commands/utils/command_errors.py
+++ b/simple_deploy/management/commands/utils/command_errors.py
@@ -16,6 +16,7 @@ class SimpleDeployCommandError(CommandError):
 
     def __init__(self, message):
         from .plugin_utils import log_info
+
         log_info("\nSimpleDeployCommandError:")
         log_info(message)
         super().__init__(message)

--- a/simple_deploy/management/commands/utils/command_errors.py
+++ b/simple_deploy/management/commands/utils/command_errors.py
@@ -1,7 +1,5 @@
 from django.core.management.base import CommandError
 
-# from .plugin_utils import log_info
-
 
 class SimpleDeployCommandError(CommandError):
     """Simple wrapper around CommandError, to facilitate consistent
@@ -15,6 +13,11 @@ class SimpleDeployCommandError(CommandError):
     """
 
     def __init__(self, message):
+        """Log the error, and then raise a standard CommandError."""
+
+        # Importing plugin_utils or log_info at the module level causes a circular
+        # import error, because plugin_utils imports SimpleDeployCommandError.
+        # This seems like a reasonable place to avoid the circular import.
         from .plugin_utils import log_info
 
         log_info("\nSimpleDeployCommandError:")

--- a/simple_deploy/management/commands/utils/command_errors.py
+++ b/simple_deploy/management/commands/utils/command_errors.py
@@ -1,0 +1,21 @@
+from django.core.management.base import CommandError
+
+# from .plugin_utils import log_info
+
+
+class SimpleDeployCommandError(CommandError):
+    """Simple wrapper around CommandError, to facilitate consistent
+    logging of command errors.
+
+    Writes "SimpleDeployCommandError:" and error message to log, then raises
+    actual CommandError.
+
+    Note: This changes the exception type from CommandError to
+    SimpleDeployCommandError.
+    """
+
+    def __init__(self, message):
+        from .plugin_utils import log_info
+        log_info("\nSimpleDeployCommandError:")
+        log_info(message)
+        super().__init__(message)

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -32,7 +32,6 @@ from .command_errors import SimpleDeployCommandError
 # and then accessible by plugins. This approach keeps from having to pass the config
 # instance between core, plugins, and these utility functions.
 sd_config = SDConfig()
-print("sd_config id:", id(sd_config))
 
 
 # class SimpleDeployCommandError(CommandError):

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -10,6 +10,7 @@ import shlex
 import toml
 
 from django.template.engine import Engine, Context
+
 # from django.core.management.base import CommandError
 
 from .. import sd_messages

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -10,37 +10,46 @@ import shlex
 import toml
 
 from django.template.engine import Engine, Context
-from django.core.management.base import CommandError
+# from django.core.management.base import CommandError
 
 from .. import sd_messages
+from .sd_config import SDConfig
+from .command_errors import SimpleDeployCommandError
+
 
 # --- Utilities that require an instance of Command ---
 
 
-def init(config):
-    """Make sd_config instance available to all functions in this module.
+# def init(config):
+#     """Make sd_config instance available to all functions in this module.
 
-    This is called once in simple_deploy.py, and does not need to be called again.
-    """
-    global sd_config
-    sd_config = config
+#     This is called once in simple_deploy.py, and does not need to be called again.
+#     """
+#     global sd_config
+#     sd_config = config
+
+# sd_config is created once right here. The attributes are set by simple_deploy,
+# and then accessible by plugins. This approach keeps from having to pass the config
+# instance between core, plugins, and these utility functions.
+sd_config = SDConfig()
+print("sd_config id:", id(sd_config))
 
 
-class SimpleDeployCommandError(CommandError):
-    """Simple wrapper around CommandError, to facilitate consistent
-    logging of command errors.
+# class SimpleDeployCommandError(CommandError):
+#     """Simple wrapper around CommandError, to facilitate consistent
+#     logging of command errors.
 
-    Writes "SimpleDeployCommandError:" and error message to log, then raises
-    actual CommandError.
+#     Writes "SimpleDeployCommandError:" and error message to log, then raises
+#     actual CommandError.
 
-    Note: This changes the exception type from CommandError to
-    SimpleDeployCommandError.
-    """
+#     Note: This changes the exception type from CommandError to
+#     SimpleDeployCommandError.
+#     """
 
-    def __init__(self, message):
-        log_info("\nSimpleDeployCommandError:")
-        log_info(message)
-        super().__init__(message)
+#     def __init__(self, message):
+#         log_info("\nSimpleDeployCommandError:")
+#         log_info(message)
+#         super().__init__(message)
 
 
 def add_file(path, contents):

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -16,7 +16,7 @@ from .sd_config import SDConfig
 from .command_errors import SimpleDeployCommandError
 
 
-# sd_config is created once right here. The attributes are set by simple_deploy,
+# Create sd_config once right here. The attributes are set by simple_deploy,
 # and then accessible by plugins. This approach keeps from having to pass the config
 # instance between core, plugins, and these utility functions.
 sd_config = SDConfig()

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -11,45 +11,15 @@ import toml
 
 from django.template.engine import Engine, Context
 
-# from django.core.management.base import CommandError
-
 from .. import sd_messages
 from .sd_config import SDConfig
 from .command_errors import SimpleDeployCommandError
 
 
-# --- Utilities that require an instance of Command ---
-
-
-# def init(config):
-#     """Make sd_config instance available to all functions in this module.
-
-#     This is called once in simple_deploy.py, and does not need to be called again.
-#     """
-#     global sd_config
-#     sd_config = config
-
 # sd_config is created once right here. The attributes are set by simple_deploy,
 # and then accessible by plugins. This approach keeps from having to pass the config
 # instance between core, plugins, and these utility functions.
 sd_config = SDConfig()
-
-
-# class SimpleDeployCommandError(CommandError):
-#     """Simple wrapper around CommandError, to facilitate consistent
-#     logging of command errors.
-
-#     Writes "SimpleDeployCommandError:" and error message to log, then raises
-#     actual CommandError.
-
-#     Note: This changes the exception type from CommandError to
-#     SimpleDeployCommandError.
-#     """
-
-#     def __init__(self, message):
-#         log_info("\nSimpleDeployCommandError:")
-#         log_info(message)
-#         super().__init__(message)
 
 
 def add_file(path, contents):
@@ -394,11 +364,6 @@ def add_package(package_name, version=""):
         add_req_txt_pkg(sd_config.req_txt_path, package_name, version)
 
     write_output(f"  Added {package_name} to requirements file.")
-
-
-# --- Utilities that do not require an instance of SDConfig ---
-# Note: These utilities are much easier to test, and should
-# be preferred when possible.
 
 
 def get_template_string(template_path, context):

--- a/simple_deploy/management/commands/utils/sd_config.py
+++ b/simple_deploy/management/commands/utils/sd_config.py
@@ -5,7 +5,7 @@ class SDConfig:
     """Class for managing attributes of Command that need to be shared with plugins.
 
     This is instantiated once at the module level in plugin_utils. That instance is
-    imported into simple_deploy, where Command defines all relevant attributes, and 
+    imported into simple_deploy, where Command defines all relevant attributes, and
     calls validate().
 
     Plugins then import the sd_config instance from plugin_utils. If mutability is an
@@ -13,7 +13,7 @@ class SDConfig:
     a singleton class.
 
     No module other than plugin_utils should import this class directly, or otherwise
-    make an instance of this class. All access should happen through the sd_config 
+    make an instance of this class. All access should happen through the sd_config
     variable in plugin_utils.
     """
 

--- a/simple_deploy/management/commands/utils/sd_config.py
+++ b/simple_deploy/management/commands/utils/sd_config.py
@@ -1,9 +1,21 @@
-# from .plugin_utils import SimpleDeployCommandError
 from .command_errors import SimpleDeployCommandError
 
 
 class SDConfig:
-    """Class for managing attributes of Command that need to be shared with plugins."""
+    """Class for managing attributes of Command that need to be shared with plugins.
+
+    This is instantiated once at the module level in plugin_utils. That instance is
+    imported into simple_deploy, where Command defines all relevant attributes, and 
+    calls validate().
+
+    Plugins then import the sd_config instance from plugin_utils. If mutability is an
+    issue, or if multiple instances of SDConfig are being created, consider making this
+    a singleton class.
+
+    No module other than plugin_utils should import this class directly, or otherwise
+    make an instance of this class. All access should happen through the sd_config 
+    variable in plugin_utils.
+    """
 
     def __init__(self):
         """Define all attributes that will need to be shared."""

--- a/simple_deploy/management/commands/utils/sd_config.py
+++ b/simple_deploy/management/commands/utils/sd_config.py
@@ -1,10 +1,11 @@
-from .plugin_utils import SimpleDeployCommandError
+# from .plugin_utils import SimpleDeployCommandError
+from .command_errors import SimpleDeployCommandError
 
 
 class SDConfig:
     """Class for managing attributes of Command that need to be shared with plugins."""
 
-    def __init__(self, stdout):
+    def __init__(self):
         """Define all attributes that will need to be shared."""
         # Aspects of user's system.
         self.on_windows = None
@@ -34,7 +35,7 @@ class SDConfig:
         self.use_shell = None
         self.e2e_testing = None
         self.unit_testing = None
-        self.stdout = stdout
+        self.stdout = None
 
     def validate(self):
         """Make sure all required attributes have been defined."""
@@ -52,4 +53,8 @@ class SDConfig:
 
         if self.settings_path is None:
             msg = "Could not identify path to settings.py."
+            raise SimpleDeployCommandError(msg)
+
+        if self.stdout is None:
+            msg = "Failed to access stdout."
             raise SimpleDeployCommandError(msg)

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,4 +1,7 @@
-"""Tests for simple_deploy/management/commands/utils.py."""
+"""Tests for simple_deploy/management/commands/utils.py.
+
+Note: May need to rethink handling of sd_config, if tests start to affect each other.
+"""
 
 from pathlib import Path
 import filecmp
@@ -6,7 +9,7 @@ import sys
 
 from simple_deploy.management.commands.utils import sd_utils
 from simple_deploy.management.commands.utils import plugin_utils
-from simple_deploy.management.commands.utils.plugin_utils import sd_config as mock_sdconfig
+from simple_deploy.management.commands.utils.plugin_utils import sd_config
 import subprocess
 
 import pytest
@@ -151,24 +154,16 @@ def test_add_pipenv_pkg(tmp_path):
 # --- Tests for functions that require sd_config ---
 
 
-def test_add_file(tmp_path):#, mock_sdconfig):
+def test_add_file(tmp_path):
     """Test utility for adding a file."""
+    sd_config.unit_testing = "True"
+    sd_config.stdout = sys.stdout
+
     contents = "Sample file contents.\n"
     path = tmp_path / "test_add_file.txt"
-
     assert not path.exists()
 
-    mock_sdconfig.unit_testing = "True"
-    assert mock_sdconfig.stdout is None
-    mock_sdconfig.stdout = sys.stdout
-    assert mock_sdconfig.stdout is not None
-    # import sys
-    sys.stdout.write("\n*** Hello testing world!")
-    mock_sdconfig.stdout.write("\n*** Hello again testing world!")
-    print("\nmock_sdconfig id:", id(mock_sdconfig))
-    # plugin_utils.init(mock_sdconfig)
     plugin_utils.add_file(path, contents)
-
     assert path.exists()
 
     contents_from_file = path.read_text()

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -18,7 +18,6 @@ import pytest
 # --- Fixtures ---
 
 
-
 # --- Test functions ---
 
 

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -6,7 +6,7 @@ import sys
 
 from simple_deploy.management.commands.utils import sd_utils
 from simple_deploy.management.commands.utils import plugin_utils
-from simple_deploy.management.commands.utils.sd_config import SDConfig
+from simple_deploy.management.commands.utils.plugin_utils import sd_config as mock_sdconfig
 import subprocess
 
 import pytest
@@ -14,12 +14,6 @@ import pytest
 
 # --- Fixtures ---
 
-
-@pytest.fixture()
-def mock_sdconfig():
-    sd_config = SDConfig(stdout=None)
-    # Define any settings here that would be helpful for multiple tests.
-    return sd_config
 
 
 # --- Test functions ---
@@ -157,7 +151,7 @@ def test_add_pipenv_pkg(tmp_path):
 # --- Tests for functions that require sd_config ---
 
 
-def test_add_file(tmp_path, mock_sdconfig):
+def test_add_file(tmp_path):#, mock_sdconfig):
     """Test utility for adding a file."""
     contents = "Sample file contents.\n"
     path = tmp_path / "test_add_file.txt"
@@ -165,8 +159,14 @@ def test_add_file(tmp_path, mock_sdconfig):
     assert not path.exists()
 
     mock_sdconfig.unit_testing = "True"
+    assert mock_sdconfig.stdout is None
     mock_sdconfig.stdout = sys.stdout
-    plugin_utils.init(mock_sdconfig)
+    assert mock_sdconfig.stdout is not None
+    # import sys
+    sys.stdout.write("\n*** Hello testing world!")
+    mock_sdconfig.stdout.write("\n*** Hello again testing world!")
+    print("\nmock_sdconfig id:", id(mock_sdconfig))
+    # plugin_utils.init(mock_sdconfig)
     plugin_utils.add_file(path, contents)
 
     assert path.exists()


### PR DESCRIPTION
Using `global` was a nice way to get away from some really awkward structure for passing around config info, but it doesn't sit well with anyone. Thanks to Trey Hunner's excellent and thorough [article about singletons](https://www.pythonmorsels.com/making-singletons/), this PR avoids the use of global, also leading to simpler usage of `SimpleDeployCommandError`.

- `SDConfig` is instantiated once, at module level in `plugin_utils.py`.
- It's imported directly into simple_deploy.py and each plugin's `platform_deployer` module.
- Attributes are set by `Command`, and read by plugins as needed.
- `SimpleDeployCommandError` is moved to its own module, and imported directly into any module that needs it.