### PR TITLE
Add a modify_settings_file() plugin utility function

### DIFF
--- a/simple_deploy/management/commands/fly_io/platform_deployer.py
+++ b/simple_deploy/management/commands/fly_io/platform_deployer.py
@@ -172,19 +172,21 @@ class PlatformDeployer:
         # Get modified version of settings.
         template_path = self.templates_path / "settings.py"
 
-        settings_string = sd_config.settings_path.read_text()
-        safe_settings_string = mark_safe(settings_string)
+        # settings_string = sd_config.settings_path.read_text()
+        # safe_settings_string = mark_safe(settings_string)
         context = {
-            "current_settings": safe_settings_string,
+            # "current_settings": safe_settings_string,
             "deployed_project_name": self.deployed_project_name,
         }
 
-        modified_settings_string = plugin_utils.get_template_string(
-            template_path, context
-        )
+        # modified_settings_string = plugin_utils.get_template_string(
+        #     template_path, context
+        # )
 
-        # Write settings to file.
-        plugin_utils.modify_file(sd_config.settings_path, modified_settings_string)
+        # # Write settings to file.
+        # plugin_utils.modify_file(sd_config.settings_path, modified_settings_string)
+
+        plugin_utils.modify_settings_file(template_path, context)
 
     def _add_requirements(self):
         """Add requirements for deploying to Fly.io."""

--- a/simple_deploy/management/commands/fly_io/platform_deployer.py
+++ b/simple_deploy/management/commands/fly_io/platform_deployer.py
@@ -169,22 +169,10 @@ class PlatformDeployer:
 
     def _modify_settings(self):
         """Add platformsh-specific settings."""
-        # Get modified version of settings.
         template_path = self.templates_path / "settings.py"
-
-        # settings_string = sd_config.settings_path.read_text()
-        # safe_settings_string = mark_safe(settings_string)
         context = {
-            # "current_settings": safe_settings_string,
             "deployed_project_name": self.deployed_project_name,
         }
-
-        # modified_settings_string = plugin_utils.get_template_string(
-        #     template_path, context
-        # )
-
-        # # Write settings to file.
-        # plugin_utils.modify_file(sd_config.settings_path, modified_settings_string)
 
         plugin_utils.modify_settings_file(template_path, context)
 

--- a/simple_deploy/management/commands/heroku/platform_deployer.py
+++ b/simple_deploy/management/commands/heroku/platform_deployer.py
@@ -227,19 +227,8 @@ class PlatformDeployer:
         This settings block is currently the same for all users. The ALLOWED_HOSTS
         setting should be customized.
         """
-        # Generate modified settings string.
         template_path = self.templates_path / "settings.py"
-
-        settings_string = sd_config.settings_path.read_text()
-        safe_settings_string = mark_safe(settings_string)
-        context = {"current_settings": safe_settings_string}
-
-        modified_settings_string = plugin_utils.get_template_string(
-            template_path, context
-        )
-
-        # Write settings to file.
-        plugin_utils.modify_file(sd_config.settings_path, modified_settings_string)
+        plugin_utils.modify_settings_file(template_path)
 
     def _conclude_automate_all(self):
         """Finish automating the push to Heroku."""

--- a/simple_deploy/management/commands/platform_sh/platform_deployer.py
+++ b/simple_deploy/management/commands/platform_sh/platform_deployer.py
@@ -124,19 +124,8 @@ class PlatformDeployer:
         This settings block is currently the same for all users. The ALLOWED_HOSTS
         setting should be customized.
         """
-        # Generate modified settings string.
         template_path = self.templates_path / "settings.py"
-
-        settings_string = sd_config.settings_path.read_text()
-        safe_settings_string = mark_safe(settings_string)
-        context = {"current_settings": safe_settings_string}
-
-        modified_settings_string = plugin_utils.get_template_string(
-            template_path, context
-        )
-
-        # Write settings to file.
-        plugin_utils.modify_file(sd_config.settings_path, modified_settings_string)
+        plugin_utils.modify_settings_file(template_path)
 
     def _add_platform_app_yaml(self):
         """Add a .platform.app.yaml file."""

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -10,6 +10,7 @@ import shlex
 import toml
 
 from django.template.engine import Engine, Context
+from django.utils.safestring import mark_safe
 
 from .. import sd_messages
 from .sd_config import SDConfig
@@ -78,6 +79,22 @@ def modify_file(path, contents):
     path.write_text(contents)
     msg = f"  Modified file: {path.as_posix()}"
     write_output(msg)
+
+
+def modify_settings_file(template_path, context):
+    """Add a platform-specific settings block to settings.py."""
+
+    # Add current settings to context.
+    settings_string = sd_config.settings_path.read_text()
+    safe_settings_string = mark_safe(settings_string)
+    context["current_settings"] = safe_settings_string
+
+    modified_settings_string = get_template_string(
+        template_path, context
+    )
+
+    # Write settings to file.
+    modify_file(sd_config.settings_path, modified_settings_string)
 
 
 def add_dir(path):

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -82,8 +82,11 @@ def modify_file(path, contents):
 
 
 def modify_settings_file(template_path, context):
-    """Add a platform-specific settings block to settings.py."""
+    """Add a platform-specific settings block to settings.py.
 
+    Provide a path to a template including current settings and the platform-specific
+    settings block, and a context dictionary.
+    """
     # Add current settings to context.
     settings_string = sd_config.settings_path.read_text()
     safe_settings_string = mark_safe(settings_string)

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -92,9 +92,7 @@ def modify_settings_file(template_path, context):
     safe_settings_string = mark_safe(settings_string)
     context["current_settings"] = safe_settings_string
 
-    modified_settings_string = get_template_string(
-        template_path, context
-    )
+    modified_settings_string = get_template_string(template_path, context)
 
     # Write settings to file.
     modify_file(sd_config.settings_path, modified_settings_string)

--- a/simple_deploy/management/commands/utils/plugin_utils.py
+++ b/simple_deploy/management/commands/utils/plugin_utils.py
@@ -81,12 +81,14 @@ def modify_file(path, contents):
     write_output(msg)
 
 
-def modify_settings_file(template_path, context):
+def modify_settings_file(template_path, context=None):
     """Add a platform-specific settings block to settings.py.
 
     Provide a path to a template including current settings and the platform-specific
     settings block, and a context dictionary.
     """
+    if context is None:
+        context = {}
     # Add current settings to context.
     settings_string = sd_config.settings_path.read_text()
     safe_settings_string = mark_safe(settings_string)


### PR DESCRIPTION
Almost every plugin will modify settings.py. The bodies of `_modify_settings()` was almost identical in each platform deployer. Pull common functionality out into a utility function.