### PR TITLE
Support wagtail deployments.

### DIFF
--- a/django_simple_deploy/management/commands/deploy.py
+++ b/django_simple_deploy/management/commands/deploy.py
@@ -297,24 +297,6 @@ class Command(BaseCommand):
 
         dsd_config.settings_path = self._get_settings_path()
 
-        # # Look for a standard settings.py file first.
-        # dsd_config.settings_path = (
-        #     dsd_config.project_root / dsd_config.local_project_name / "settings.py"
-        # )
-        # if not dsd_config.settings_path.exists():
-        #     # Try a settings dir, with production.py. This is Wagtail's structure.
-        #     dsd_config.settings_path = (
-        #         dsd_config.project_root / dsd_config.local_project_name / "settings" / "production.py"
-        #         # dsd_config.project_root / dsd_config.local_project_name / "settings" / "base.py"
-        #     )
-
-        # if not dsd_config.settings_path.exists():
-        #     standard_path = dsd_config.project_root / dsd_config.local_project_name / "settings.py"
-        #     wagtail_path = dsd_config.project_root / dsd_config.local_project_name / "settings" / "production.py"
-        #     # wagtail_path = dsd_config.project_root / dsd_config.local_project_name / "settings" / "base.py"
-        #     error_msg = f"Couldn't find a settings file. Tried {standard_path.as_posix()} and {wagtail_path.as_posix()}"
-        #     raise DSDCommandError(error_msg)
-
         # Find out which package manager is being used: req_txt, poetry, or pipenv
         dsd_config.pkg_manager = self._get_dep_man_approach()
         msg = f"Dependency management system: {dsd_config.pkg_manager}"


### PR DESCRIPTION
Wrap `Path()` around `settings.BASE_DIR` because Wagtail still uses strings for paths. New method in `Command()`, `_get_settings_path()`. Looks for a standard `project_name/settings.py`, then for `project_name/settings/production.py`. This supports the Wagtail approach of splitting settings into base.py, dev.py, and production.py.