### PR TITLE
Fix console issues on Windows

### DIFF
--- a/django_simple_deploy/management/commands/utils/plugin_utils.py
+++ b/django_simple_deploy/management/commands/utils/plugin_utils.py
@@ -314,7 +314,14 @@ def write_output(output, write_to_console=True, skip_logging=False):
     output_str = get_string_from_output(output)
 
     if write_to_console and not logs_to_console():
-        dsd_config.stdout.write(output_str)
+        try:
+            dsd_config.stdout.write(output_str)
+        except UnicodeEncodeError:
+            # This is motivated by an error writing Unicode characters in 
+            # Git Bash consoles on Windows.
+            encoding = getattr(dsd_config.stdout, "encoding", None) or "utf-8"
+            safe_output_str = output_str.encode(encoding, errors="backslashreplace").decode(encoding, errors="replace")
+            dsd_config.stdout.write(safe_output_str)
 
     if not skip_logging:
         log_info(output_str)

--- a/django_simple_deploy/management/commands/utils/plugin_utils.py
+++ b/django_simple_deploy/management/commands/utils/plugin_utils.py
@@ -323,6 +323,13 @@ def write_output(output, write_to_console=True, skip_logging=False):
             safe_output_str = output_str.encode(encoding, errors="backslashreplace").decode(encoding, errors="replace")
             dsd_config.stdout.write(safe_output_str)
 
+        # Flush, to avoid any buffering in consoles.
+        try:
+            dsd_config.stdout.flush()
+        except Exception:
+            # Continue silently if the console does not support flushing.
+            pass
+
     if not skip_logging:
         log_info(output_str)
 


### PR DESCRIPTION
This PR fixes a couple issues that have come up on Git Bash consoles on Windows. If the console raises a unicode exception, just write the character code instead of the symbol. Also, flush stream after each write, so we don't run into buffering issues.